### PR TITLE
Improve API

### DIFF
--- a/qiskit_metal/renderers/renderer_qtcad/qtcad_renderer.py
+++ b/qiskit_metal/renderers/renderer_qtcad/qtcad_renderer.py
@@ -644,7 +644,7 @@ class QQTCADRenderer(QRendererAnalysis):
         if isinstance(self._options["capacitance_raw"], dict):
             self.logger.info("In the renderer's `options` argument, the key `capacitance_raw` was"
                              " defined."
-                             " The capacitance solver parameters defined using the standard"
+                             " Any capacitance solver parameters defined using the standard"
                              " `capacitance` key are going to be overwritten.")
 
         if not isinstance(self._options["maxwell_emode_raw"], (type(None), dict)):
@@ -658,7 +658,7 @@ class QQTCADRenderer(QRendererAnalysis):
         if isinstance(self._options["maxwell_emode_raw"], dict):
             self.logger.info("In the renderer's `options` argument, the key `maxwell_emode_raw`"
                              " was defined."
-                             " The Maxwell eigemode solver parameters defined using the standard"
+                             " Any Maxwell eigemode solver parameters defined using the standard"
                              " `maxwell_emode` key are going to be overwritten.")
 
     def export_parameters(self, json_filepath=None):

--- a/qiskit_metal/renderers/renderer_qtcad/qtcad_renderer.py
+++ b/qiskit_metal/renderers/renderer_qtcad/qtcad_renderer.py
@@ -69,17 +69,17 @@ class QQTCADRenderer(QRendererAnalysis):
 
         * capacitance_raw -- Dictionary of parameters to be passed directly to QTCAD's capacitance
                              extractor solver via `qtcad.device.capacitance.SolverParams`.
-                             Overwrites `QQTCADRenderer.capacitance`'s parameters such that
-                             _any_ parameters from `capacitance` are ignored (see note), with
-                             the defaults from `qtcad.device.capacitance.SolverParams` (see its
-                             docstring for their values) taking precedence, with the exception of
-                             `output_dir`, `make_subdir` and `name`, which are defined by the
-                             parameters of `QQTCADRenderer`.
+                             Overwrites the parameters defined in `capacitance`: _any_ parameters
+                             from `capacitance` are ignored (see note) and the defaults from
+                             `qtcad.device.capacitance.SolverParams` (see its docstring for their
+                             values) take precedence, with the exception of `output_dir`,
+                             `make_subdir` and `name`, which are defined by the parameters of
+                             `QQTCADRenderer`.
 
             Note:
-                For users who want full control of the solver, with `QQTCADRenderer.capacitance`
-                being enough for most applications. The keys should be the parameters accepted by
-                `qtcad.device.capacitance.SolverParams`.
+                For users who want full control of the solver, with the `capacitance` entry in
+                `options` being enough for most applications. The keys should be the parameters
+                accepted by `qtcad.device.capacitance.SolverParams`.
 
         * maxwell_emode -- Dictionary of parameters specific to the Maxwell eigenmode
                            extractor.
@@ -93,17 +93,17 @@ class QQTCADRenderer(QRendererAnalysis):
         * maxwell_emode_raw -- Dictionary of parameters to be passed directly to QTCAD's Maxwell
                                eigenmode extractor solver via
                                `qtcad.device.maxwell_eigenmode.SolverParams`.
-                               Overwrites `QQTCADRenderer.maxwell_emode`'s parameters such that
-                             _any_ parameters from `capacitance` are ignored (see note), with
-                             the defaults from `qtcad.device.capacitance.SolverParams` (see its
-                             docstring for their values) taking precedence, with the exception of
-                             `output_dir`, `make_subdir` and `name`, which are defined by the
-                             parameters of `QQTCADRenderer`.
+                               Overwrites the parameters defined in `maxwell_emode`: _any_
+                               parameters from `maxwell_emode` are ignored (see note) and the
+                               defaults from `qtcad.device.maxwell_eigenmode.SolverParams` (see
+                               its docstring for their values) take precedence, with the exception
+                               of `output_dir`, `make_subdir` and `name`, which are defined by the
+                               parameters of `QQTCADRenderer`.
 
             Note:
-                For users who want full control of the solver, with
-                `QQTCADRenderer.maxwell_eigenmode` being enough for most applications. The keys
-                should be the parameters accepted by `qtcad.device.maxwell_eigenmode.SolverParams`.
+                For users who want full control of the solver, with the `maxwell_eigenmode` entry
+                in `options` being enough for most applications. The keys should be the parameters
+                accepted by `qtcad.device.maxwell_eigenmode.SolverParams`.
     """
 
     # The defaults of a renderer must be in a dict named `default_options`. They

--- a/qiskit_metal/renderers/renderer_qtcad/qtcad_renderer.py
+++ b/qiskit_metal/renderers/renderer_qtcad/qtcad_renderer.py
@@ -116,7 +116,7 @@ class QQTCADRenderer(QRendererAnalysis):
         output_dir=".",
         geo_filepath="qiskit_device.xao",
         mesh_filepath="qiskit_device.msh4",
-        mesh_scale=1-3,
+        mesh_scale=1e-3,
         materials=default_materials,
         make_subdir=True,
         capacitance=dict(

--- a/qiskit_metal/renderers/renderer_qtcad/qtcad_renderer.py
+++ b/qiskit_metal/renderers/renderer_qtcad/qtcad_renderer.py
@@ -69,14 +69,17 @@ class QQTCADRenderer(QRendererAnalysis):
 
         * capacitance_raw -- Dictionary of parameters to be passed directly to QTCAD's capacitance
                              extractor solver via `qtcad.device.capacitance.SolverParams`.
-                             Overwrites `QQTCADRenderer.capacitance`'s parameters.
+                             Overwrites `QQTCADRenderer.capacitance`'s parameters such that
+                             _any_ parameters from `capacitance` are ignored (see note), with
+                             the defaults from `qtcad.device.capacitance.SolverParams` (see its
+                             docstring for their values) taking precedence, with the exception of
+                             `output_dir`, `make_subdir` and `name`, which are defined by the
+                             parameters of `QQTCADRenderer`.
 
             Note:
                 For users who want full control of the solver, with `QQTCADRenderer.capacitance`
                 being enough for most applications. The keys should be the parameters accepted by
-                `qtcad.device.capacitance.SolverParams`. The exceptions are the parameters
-                `output_dir`, `make_subdir` and `name`, which will be defined from
-                `QQTCADRenderer`'s own parameters.
+                `qtcad.device.capacitance.SolverParams`.
 
         * maxwell_emode -- Dictionary of parameters specific to the Maxwell eigenmode
                            extractor.
@@ -90,14 +93,17 @@ class QQTCADRenderer(QRendererAnalysis):
         * maxwell_emode_raw -- Dictionary of parameters to be passed directly to QTCAD's Maxwell
                                eigenmode extractor solver via
                                `qtcad.device.maxwell_eigenmode.SolverParams`.
-                               Overwrites `QQTCADRenderer.maxwell_emode`'s parameters.
+                               Overwrites `QQTCADRenderer.maxwell_emode`'s parameters such that
+                             _any_ parameters from `capacitance` are ignored (see note), with
+                             the defaults from `qtcad.device.capacitance.SolverParams` (see its
+                             docstring for their values) taking precedence, with the exception of
+                             `output_dir`, `make_subdir` and `name`, which are defined by the
+                             parameters of `QQTCADRenderer`.
 
             Note:
                 For users who want full control of the solver, with
                 `QQTCADRenderer.maxwell_eigenmode` being enough for most applications. The keys
                 should be the parameters accepted by `qtcad.device.maxwell_eigenmode.SolverParams`.
-                The exceptions are the parameters `output_dir`, `make_subdir` and `name`, which
-                will be defined from `QQTCADRenderer`'s own parameters.
     """
 
     # The defaults of a renderer must be in a dict named `default_options`. They

--- a/qiskit_metal/renderers/renderer_qtcad/qtcad_renderer.py
+++ b/qiskit_metal/renderers/renderer_qtcad/qtcad_renderer.py
@@ -634,32 +634,34 @@ class QQTCADRenderer(QRendererAnalysis):
 
     def _validate_options(self):
         if not isinstance(self._options["capacitance_raw"], (type(None), dict)):
-            error = TypeError("`QQTCADRenderer.capacitance_raw` should either be a dictionary"
-                              " with the parameters allowed by"
-                              " `qtcad.device.maxwell_eigenmode.SolverParams` or left unset."
-                              " Please check the `options` parameters used to instantiate the"
-                              " QTCAD renderer.")
-            self.logger.error(error)
-            raise error
+            error_msg = TypeError("`QQTCADRenderer.capacitance_raw` should either be a dictionary"
+                                  " with the parameters allowed by"
+                                  " `qtcad.device.maxwell_eigenmode.SolverParams` or left unset."
+                                  " Please check the `options` parameters used to instantiate the"
+                                  " QTCAD renderer.")
+            self.logger.error(error_msg)
+            raise error_msg
         if isinstance(self._options["capacitance_raw"], dict):
-            self.logger.info("In the renderer's `options` argument, the key `capacitance_raw` was"
-                             " defined."
-                             " Any capacitance solver parameters defined using the standard"
-                             " `capacitance` key are going to be overwritten.")
+            warning_msg = ("In the renderer's `options` argument, the key `capacitance_raw` was"
+                           " defined."
+                           " Any capacitance solver parameters defined using the standard"
+                           " `capacitance` key are going to be overwritten.")
+            self.logger.warning(warning_msg)
 
         if not isinstance(self._options["maxwell_emode_raw"], (type(None), dict)):
-            error = TypeError("`QQTCADRenderer.maxwell_emode_raw` should either be a dictionary"
-                              " with the parameters allowed by"
-                              " `qtcad.device.maxwell_eigenmode.SolverParams` or left unset."
-                              " Please check the `options` parameters used to instantiate the"
-                              " QTCAD renderer.")
-            self.logger.error(error)
-            raise error
+            error_msg = TypeError("`QQTCADRenderer.maxwell_emode_raw` should either be a"
+                                  " dictionary with the parameters allowed by"
+                                  " `qtcad.device.maxwell_eigenmode.SolverParams` or left unset."
+                                  " Please check the `options` parameters used to instantiate the"
+                                  " QTCAD renderer.")
+            self.logger.error(error_msg)
+            raise error_msg
         if isinstance(self._options["maxwell_emode_raw"], dict):
-            self.logger.info("In the renderer's `options` argument, the key `maxwell_emode_raw`"
-                             " was defined."
-                             " Any Maxwell eigemode solver parameters defined using the standard"
-                             " `maxwell_emode` key are going to be overwritten.")
+            warning_msg = ("In the renderer's `options` argument, the key `maxwell_emode_raw`"
+                           " was defined."
+                           " Any Maxwell eigemode solver parameters defined using the standard"
+                           " `maxwell_emode` key are going to be overwritten.")
+            self.logger.warning(warning_msg)
 
     def export_parameters(self, json_filepath=None):
         """Exports parameters that are required for QTCAD simulations as a JSON file."""

--- a/qiskit_metal/renderers/renderer_qtcad/qtcad_renderer.py
+++ b/qiskit_metal/renderers/renderer_qtcad/qtcad_renderer.py
@@ -58,8 +58,8 @@ class QQTCADRenderer(QRendererAnalysis):
             * tol_rel: relative tolerance (see Note). Defaults to 0.05.
             * tol_abs: absolute tolerance (see Note). Defaults to 0.0.
             * min_converged_iters -- How many consecutive iterations are required to give
-                                 results that agree within the tolerance thresholds.
-                                 Default: 3.
+                                     results that agree within the tolerance thresholds.
+                                     Default: 3.
 
             Note:
                 The convergence threshold for each entry of the capacitance
@@ -67,13 +67,37 @@ class QQTCADRenderer(QRendererAnalysis):
                 tol_abs is useful when :math:`|C_{ij}|` is expected to be zero or
                 very small.
 
-        * maxwell_emode -- Dictionary of parameters specific to the Maxwell eigenmode
-                                        extractor.
+        * capacitance_raw -- Dictionary of parameters to be passed directly to QTCAD's capacitance
+                             extractor solver via `qtcad.device.capacitance.SolverParams`.
+                             Overwrites `QQTCADRenderer.capacitance`'s parameters.
 
-            * tol_rel: relative tolerance on the frequency. Defaults to 0.05.
+            Note:
+                For users who want full control of the solver, with `QQTCADRenderer.capacitance`
+                being enough for most applications. The keys should be the parameters accepted by
+                `qtcad.device.capacitance.SolverParams`. The exceptions are the parameters
+                `output_dir`, `make_subdir` and `name`, which will be defined from
+                `QQTCADRenderer`'s own parameters.
+
+        * maxwell_emode -- Dictionary of parameters specific to the Maxwell eigenmode
+                           extractor.
+
+            * num_modes: Number of modes to solve for. Default: 3.
+            * tol_rel: Relative tolerance on the frequency. Default: 0.05.
             * min_converged_iters -- How many consecutive iterations are required to give
-                                 results that agree within the tolerance thresholds.
-                                 Default: 5.
+                                     results that agree within the tolerance thresholds.
+                                     Default: 5.
+
+        * maxwell_emode_raw -- Dictionary of parameters to be passed directly to QTCAD's Maxwell
+                               eigenmode extractor solver via
+                               `qtcad.device.maxwell_eigenmode.SolverParams`.
+                               Overwrites `QQTCADRenderer.maxwell_emode`'s parameters.
+
+            Note:
+                For users who want full control of the solver, with
+                `QQTCADRenderer.maxwell_eigenmode` being enough for most applications. The keys
+                should be the parameters accepted by `qtcad.device.maxwell_eigenmode.SolverParams`.
+                The exceptions are the parameters `output_dir`, `make_subdir` and `name`, which
+                will be defined from `QQTCADRenderer`'s own parameters.
     """
 
     # The defaults of a renderer must be in a dict named `default_options`. They
@@ -94,10 +118,13 @@ class QQTCADRenderer(QRendererAnalysis):
             tol_abs=0.0,
             min_converged_iters=3,
         ),
+        capacitance_raw=None,
         maxwell_emode=dict(
+            num_modes=3,
             tol_rel=0.05,
             min_converged_iters=5,
         ),
+        maxwell_emode_raw=None,
     )
 
     name = "qtcad"
@@ -605,9 +632,40 @@ class QQTCADRenderer(QRendererAnalysis):
         Path(self.mesh_file).parent.resolve().mkdir(exist_ok=True, parents=True)
         self.gmsh.export_mesh(self.mesh_file, scaling_factor=1)
 
+    def _validate_options(self):
+        if not isinstance(self._options["capacitance_raw"], (type(None), dict)):
+            error = TypeError("`QQTCADRenderer.capacitance_raw` should either be a dictionary"
+                              " with the parameters allowed by"
+                              " `qtcad.device.maxwell_eigenmode.SolverParams` or left unset."
+                              " Please check the `options` parameters used to instantiate the"
+                              " QTCAD renderer.")
+            self.logger.error(error)
+            raise error
+        if isinstance(self._options["capacitance_raw"], dict):
+            self.logger.info("In the renderer's `options` argument, the key `capacitance_raw` was"
+                             " defined."
+                             " The capacitance solver parameters defined using the standard"
+                             " `capacitance` key are going to be overwritten.")
+
+        if not isinstance(self._options["maxwell_emode_raw"], (type(None), dict)):
+            error = TypeError("`QQTCADRenderer.maxwell_emode_raw` should either be a dictionary"
+                              " with the parameters allowed by"
+                              " `qtcad.device.maxwell_eigenmode.SolverParams` or left unset."
+                              " Please check the `options` parameters used to instantiate the"
+                              " QTCAD renderer.")
+            self.logger.error(error)
+            raise error
+        if isinstance(self._options["maxwell_emode_raw"], dict):
+            self.logger.info("In the renderer's `options` argument, the key `maxwell_emode_raw`"
+                             " was defined."
+                             " The Maxwell eigemode solver parameters defined using the standard"
+                             " `maxwell_emode` key are going to be overwritten.")
 
     def export_parameters(self, json_filepath=None):
         """Exports parameters that are required for QTCAD simulations as a JSON file."""
+
+        # Verify if the simulation parameters are valid.
+        self._validate_options()
 
         if json_filepath is None:
             json_filepath = Path(self._options["output_dir"]) / JSON_FILENAME

--- a/qiskit_metal/renderers/renderer_qtcad/qtcad_renderer.py
+++ b/qiskit_metal/renderers/renderer_qtcad/qtcad_renderer.py
@@ -192,14 +192,6 @@ class QQTCADRenderer(QRendererAnalysis):
     def check_environment(self) -> bool:
         """Check if QTCAD is able to fully run as a renderer."""
 
-        # ParaView has a Python API, but usually it is not integrated into
-        # users’ Python environment.
-        self._check_paraview = shutil.which("paraview") is not None
-        if not self._check_paraview:
-            self.logger.warning(
-                "ParaView was not found in the user’s path."
-                " Please install it if you want post-processing visualization.")
-
         return True
 
     def render_design(
@@ -613,20 +605,6 @@ class QQTCADRenderer(QRendererAnalysis):
         Path(self.mesh_file).parent.resolve().mkdir(exist_ok=True, parents=True)
         self.gmsh.export_mesh(self.mesh_file, scaling_factor=1)
 
-    def display_post_processing_data(self, signal_conductor: str) -> None:
-        """Post-process the data output by QTCAD in ParaView.
-
-        Args:
-            signal_conductor (str): Signal conductor for post-processing.
-        """
-        if signal_conductor not in self.signal_conductors:
-            self.logger.error(
-                f"No signal conductor “{self.signal_conductors}” found in the model."
-                " The signal conductors defined in this model are:\n"
-                ", ".join([f'"{cond}"' for cond in self.signal_conductors]))
-        else:
-            arguments = ["paraview", self.post_process_files[signal_conductor]]
-            subprocess.call(arguments, cwd=self.output_dir)
 
     def export_parameters(self, json_filepath=None):
         """Exports parameters that are required for QTCAD simulations as a JSON file."""

--- a/qiskit_metal/renderers/renderer_qtcad/qtcad_renderer.py
+++ b/qiskit_metal/renderers/renderer_qtcad/qtcad_renderer.py
@@ -648,10 +648,11 @@ class QQTCADRenderer(QRendererAnalysis):
             self.logger.error(error_msg)
             raise error_msg
         if isinstance(self._options["capacitance_raw"], dict):
-            warning_msg = ("In the renderer's `options` argument, the key `capacitance_raw` was"
-                           " defined."
-                           " Any capacitance solver parameters defined using the standard"
-                           " `capacitance` key are going to be overwritten.")
+            warning_msg = (
+                "In the renderer's `options` argument, `capacitance_raw` was defined."
+                " Any capacitance solver parameters defined using the standard"
+                " `capacitance` key are going to be overwritten by `capacitance_raw` and its"
+                " defaults.")
             self.logger.warning(warning_msg)
 
         if not isinstance(self._options["maxwell_emode_raw"], (type(None), dict)):
@@ -663,10 +664,11 @@ class QQTCADRenderer(QRendererAnalysis):
             self.logger.error(error_msg)
             raise error_msg
         if isinstance(self._options["maxwell_emode_raw"], dict):
-            warning_msg = ("In the renderer's `options` argument, the key `maxwell_emode_raw`"
-                           " was defined."
-                           " Any Maxwell eigemode solver parameters defined using the standard"
-                           " `maxwell_emode` key are going to be overwritten.")
+            warning_msg = (
+                "In the renderer's `options` argument, `maxwell_emode_raw` was defined."
+                " Any Maxwell eigenmode solver parameters defined using the standard"
+                " `maxwell_emode` key are going to be overwritten by `maxwell_emode_raw` and its"
+                " defaults.")
             self.logger.warning(warning_msg)
 
     def export_parameters(self, json_filepath=None):

--- a/qiskit_metal/renderers/renderer_qtcad/wrapper.py
+++ b/qiskit_metal/renderers/renderer_qtcad/wrapper.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import Union, Optional
+from typing import Optional
 import numpy as np
 import sys
 import logging
@@ -20,7 +20,6 @@ from qtcad.device.maxwell_eigenmode import SolverParams as QtcadSolverEigParams
 from dataclasses import dataclass
 
 QISKIT_CAPACITANCE_SCALE = 1e-15
-QISKIT_NUMBER_EIGENMODES = 3
 
 QTCAD_CAP_OUTPUT_FILENAME = "qtcad_output_cap.pickle"
 QTCAD_EIG_OUTPUT_FILENAME = "qtcad_output_eigs.pickle"
@@ -197,11 +196,8 @@ class QQTCADWrapper():
         # it is a natural boundary
         # self.device.new_infinity_bnd("vacuum_box_sfs")
 
-    def solve_eigs(self, num_modes):
+    def solve_eigs(self):
         """Solve for Maxwell eigenmodes using QTCAD.
-
-        Args:
-            num_modes (int): Number of modes to solve for.
 
         Returns:
             The frequencies are stored in `device.maxwell_freqs`. The fields are
@@ -212,14 +208,21 @@ class QQTCADWrapper():
         # Instantiate SolverParams and load common attributes from the `_options`
         # attribute.
         options_maxwell_emode = self._options["maxwell_emode"]
+        options_maxwell_emode_raw = self._options["maxwell_emode_raw"]
         solver_params_eig = QtcadSolverEigParams()
-        solver_params_eig.tol_rel = options_maxwell_emode["tol_rel"]
-        solver_params_eig.min_converged_iters = options_maxwell_emode["min_converged_iters"]
+
+        if options_maxwell_emode_raw is None:
+            # Reduced set of parameters.
+            solver_params_eig.num_modes = options_maxwell_emode["num_modes"]
+            solver_params_eig.tol_rel = options_maxwell_emode["tol_rel"]
+            solver_params_eig.min_converged_iters = options_maxwell_emode["min_converged_iters"]
+        else:
+            # Pass parameters directly to `qtcad.device.maxwell_eigenmode.SolverParams`.
+            solver_params_eig = QtcadSolverEigParams(options_maxwell_emode_raw)
+
+        # Non-specialized attributes.
         solver_params_eig.output_dir = self._options["output_dir"]
         solver_params_eig.make_subdir = self._options["make_subdir"]
-
-        # Specific attributes.
-        solver_params_eig.num_modes = num_modes
         solver_params_eig.name = self.name
 
         # Parse parameters.
@@ -313,41 +316,30 @@ class QQTCADWrapper():
         raise ValueError("Device has no method `e_field` and/or `solver_eig`."
                          " Try calling `solve_eigs` before.")
 
-    def solve_cap(self,
-                  display_cap_matrix: bool = False,
-                  tol_abs: Optional[float] = None,
-                  max_cpus: Optional[int] = None):
+    def solve_cap(self):
         """Compute the capacitance matrix using QTCAD.
 
         It is stored in the attribute `capacitance_matrix`, being a
         dict[tuple[str,str], float].
-
-        Args:
-            display_cap_matrix (bool, optional): Whether or not to return the
-              capacitance matrix. Defaults to `False`.
-            tol_abs (float, optional): Absolute tolerance. Default : `None` (use
-              QTCAD's default)
-            max_cpus (int, optional): The largest number of CPUs to use during
-              the solution. Default: QTCAD's default, the number of logical CPUs
-              available.
         """
-
         # Instantiate SolverParams and load common attributes from the `_options`
         # attribute.
         options_cap = self._options["capacitance"]
+        options_cap_raw = self._options["capacitance_raw"]
         solver_params_cap = QtcadSolverCapParams()
-        solver_params_cap.tol_rel = options_cap["tol_rel"]
-        solver_params_cap.tol_abs = options_cap["tol_abs"]
-        solver_params_cap.min_converged_iters = options_cap["min_converged_iters"]
+
+        if options_cap_raw is None:
+            # Reduced set of parameters.
+            solver_params_cap.tol_rel = options_cap["tol_rel"]
+            solver_params_cap.tol_abs = options_cap["tol_abs"]
+            solver_params_cap.min_converged_iters = options_cap["min_converged_iters"]
+        else:
+            # Pass parameters directly to `qtcad.device.capacitance.SolverParams`.
+            solver_params_cap = QtcadSolverCapParams(options_cap_raw)
+
+        # Non-specialized attributes.
         solver_params_cap.output_dir = self._options["output_dir"]
         solver_params_cap.make_subdir = self._options["make_subdir"]
-
-        if tol_abs is not None:
-            solver_params_cap.tol_abs = tol_abs
-
-        if max_cpus is not None:
-            solver_params_cap.max_cpus = max_cpus
-
         solver_params_cap.name = self.name
 
         self.solver_params_cap = solver_params_cap
@@ -415,13 +407,13 @@ def main_solve_cap(json_data):
                     protocol=pickle.HIGHEST_PROTOCOL)
 
 
-def main_solve_eigs(json_data, num_modes=QISKIT_NUMBER_EIGENMODES):
+def main_solve_eigs(json_data):
 
     qtcad_wrapper = QQTCADWrapper(json_data=json_data)
     qtcad_wrapper.load_and_validate()
     qtcad_wrapper.setup("PEC")
 
-    qtcad_wrapper.solve_eigs(num_modes=num_modes)
+    qtcad_wrapper.solve_eigs()
 
     Path(qtcad_wrapper._options["output_dir"]).resolve().mkdir(exist_ok=True, parents=True)
     filepath = Path(qtcad_wrapper._options["output_dir"]) / QTCAD_EIG_OUTPUT_FILENAME


### PR DESCRIPTION
1. Add `num_modes` into the simplified eigenmode API.

2. Implement a way of passing parameters straight into `qtcad.device.{capacitance,maxwell_eigenmode}.SolverParams` via the entries `capacitance_raw` and `maxwell_emode_raw` in the `options` parameter of `QQTCADRenderer`.

    Some error and warning messages are present to make sure users understand what they are doing.