### PR TITLE
Add control over the number of threads when meshing designs (allows deterministic meshes)

### DIFF
--- a/qiskit_metal/renderers/renderer_gmsh/gmsh_renderer.py
+++ b/qiskit_metal/renderers/renderer_gmsh/gmsh_renderer.py
@@ -501,10 +501,10 @@ class QGmshRenderer(QRenderer):
 
         vecs = Vec3DArray.make_vec3DArray(
             self.parse_units_gmsh(list(qc_shapely.coords)), qc_z)
-        
+
         qc_name = self.design._components[
             path["component"]].name + '_' + clean_name(path["name"])
-        
+
         bad_fillets = bad_fillet_idxs(qc_shapely.coords, qc_fillet)
         curves = render_path_curves(vecs, qc_z, qc_fillet, qc_width,
                                     bad_fillets)

--- a/qiskit_metal/renderers/renderer_qtcad/qtcad_renderer.py
+++ b/qiskit_metal/renderers/renderer_qtcad/qtcad_renderer.py
@@ -239,6 +239,7 @@ class QQTCADRenderer(QRendererAnalysis):
         initial_mesh_h_min: str = "150um",
         initial_mesh_h_max: str = "150um",
         meshing_algorithm: int = 10,
+        num_threads: int = 1,
     ):
         """Render the design in Gmsh and apply changes to modify the geometries
         according to the type of simulation. Simulation parameters provided by
@@ -266,6 +267,11 @@ class QQTCADRenderer(QRendererAnalysis):
             meshing_algorithm (int, optional): Gmsh's 3D mesh algorithm. The
               possible values are 1 (Delaunay), 3 (initial mesh only),
               4 (frontal), 7 (MMG3D), 9 (R-tree), 10 (HXT). (Default: 10)
+            num_threads (int, optional): Number of threads for
+              parallel meshing. Defaults to 1, which guarantees the meshes to
+              be generated to be deterministic (for a given system
+              configuration and environment) when using the Delaunay or HXT
+              meshing algorithms. The latter being the recommended one.
         """
 
         # Minimal spacing between the vacuum box surface and the sample holder box.
@@ -277,6 +283,9 @@ class QQTCADRenderer(QRendererAnalysis):
         self.gmsh.options.mesh.min_size = initial_mesh_h_min
         self.gmsh.options.mesh.max_size = initial_mesh_h_max
         self.gmsh.options.mesh.algorithm_3d = meshing_algorithm
+        # Gmsh's algorithms are deterministic when meshing using a single
+        # thread, vide https://gitlab.onelab.info/gmsh/gmsh/-/issues/2255.
+        self.gmsh.options.mesh.num_threads = num_threads
 
         # For handling the case when the user wants to use
         # QQTCADRenderer from design.renderers.qtcad instance.


### PR DESCRIPTION
When using the Delaunay/HXT algorithms, meshes can be made deterministic (for a given system configuration, for a given environment) if a single thread is used[^1]. This merge request adds direct control over the number of threads used when meshing a design in `QQTCADRenderer`. The default for QTCAD is set to one thread, which, a priori, shall result in deterministic meshes.

- Original description:
  
  When using the Delaunay/HXT algorithms, meshes can be made deterministic (for a given system configuration, for a given environment) if a single thread is used[^1].
  
  This merge request adds the option to create, a priori, deterministic meshes in `QGmshRenderer`, as well as adding control over the number of threads used when meshing a design in `QQTCADRenderer`. The default for QTCAD is a single thread, which, a priori, shall result in deterministic meshes.

[^1]: https://gitlab.onelab.info/gmsh/gmsh/-/issues/2255