### PR TITLE
Release 2.0.2’

### DIFF
--- a/environment-mac.yml
+++ b/environment-mac.yml
@@ -24,6 +24,6 @@ dependencies:
   - pyyaml==6.0
   - pip==23.0
   - cython<3.0.0
+  - python-gmsh==4.13.1
   - pip:
       - pyaedt==0.6.46
-      - gmsh==4.13.1

--- a/environment.yml
+++ b/environment.yml
@@ -9,6 +9,7 @@ dependencies:
   - geopandas==0.12.2
   - ipython==8.10.0
   - matplotlib==3.7.0
+  - numpy==1.24.2
   - pandas==1.5.3
   - pint==0.20.1
   - pyepr-quantum==0.8.5.7
@@ -16,14 +17,13 @@ dependencies:
   - pyside2==5.15.8
   - qdarkstyle==3.1
   - qutip==4.7.1
+  - scipy==1.10.0
   - shapely==2.0.1
   - jupyter==1.0.0
   - scqubits==3.1.0
   - pyyaml==6.0
   - pip==23.0
   - cython<3.0.0
+  - python-gmsh==4.13.1
   - pip:
-      - numpy==1.24.2
-      - scipy==1.10.0
       - pyaedt==0.6.46
-      - gmsh==4.13.1


### PR DESCRIPTION
- Use different environment files – one for GNU/Linux and Windows and another for MacOS – as to support `QQTCADRenderer` in all the platforms officially supported by QTCAD.
- Synchronized with QTCAD 2.0.2.