### PR TITLE
Removed brep from allowed file formats

### DIFF
--- a/qiskit_metal/renderers/renderer_gmsh/gmsh_renderer.py
+++ b/qiskit_metal/renderers/renderer_gmsh/gmsh_renderer.py
@@ -1321,12 +1321,12 @@ class QGmshRenderer(QRenderer):
 
     def export_geometry(self, filepath: str):
         """Export the Gmsh geometry as a geo_unrolled, BREP or XAO file.
-        Supported formats: .geo_unrolled, .brep, .xao
+        Supported formats: .geo_unrolled, .xao
 
         Args:
             filepath (str): path of the file to export geometry to
         """
-        valid_file_exts = ["geo_unrolled", "brep", "xao"]
+        valid_file_exts = ["geo_unrolled", "xao"]
         file_ext = filepath.split(".")[-1]
         if file_ext not in valid_file_exts:
             self.logger.error(

--- a/qiskit_metal/renderers/renderer_gmsh/gmsh_renderer.py
+++ b/qiskit_metal/renderers/renderer_gmsh/gmsh_renderer.py
@@ -1349,10 +1349,10 @@ class QGmshRenderer(QRenderer):
                 "you aren't explicitly handling the mesh size fields, we recommend "
                 "to export the geometry before generating the mesh in your design as "
                 "it might interfere with your .geo_unrolled file imports.")
-        elif has_mesh and file_ext == "brep":
+        elif has_mesh and file_ext == "xao":
             self.logger.warning(
                 "WARNING: The existing model contains mesh size field definitions, "
-                "which are not needed when exporting to BREP files for use in "
+                "which are not needed when exporting to XAO files for use in "
                 "renderers that support adaptive meshing refinement (AMR). If you "
                 "are going to use AMR, consider disabling the use of mesh size "
                 "fields.")

--- a/qiskit_metal/renderers/renderer_gmsh/gmsh_renderer.py
+++ b/qiskit_metal/renderers/renderer_gmsh/gmsh_renderer.py
@@ -1320,7 +1320,7 @@ class QGmshRenderer(QRenderer):
         self.export_geometry(filepath)
 
     def export_geometry(self, filepath: str):
-        """Export the Gmsh geometry as a geo_unrolled, BREP or XAO file.
+        """Export the Gmsh geometry as a geo_unrolled or XAO file.
         Supported formats: .geo_unrolled, .xao
 
         Args:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


### What are the issues this pull addresses (issue numbers / links)?

### Did you add tests to cover your changes (yes/no)?

### Did you update the documentation accordingly (yes/no)?

### Did you read the CONTRIBUTING document (yes/no)?

### Summary
In the future, QTCAD will no longer support brep files as the raw geometry files. Hence, the allowed file formats in the Gmsh renderer are updated accordingly.



### Details and comments


