### PR TITLE
Streamline eigenmode visualization following latest QTCAD API

### DIFF
--- a/qiskit_metal/renderers/__init__.py
+++ b/qiskit_metal/renderers/__init__.py
@@ -82,6 +82,16 @@ GMSH Renderer
     Vec3DArray
 
 
+QTCAD Renderer
+--------------
+
+.. autosummary::
+    :toctree: ../stubs/
+
+    QQTCADRenderer
+    QtcadConstants
+
+
 
 """
 
@@ -112,6 +122,9 @@ if config.is_building_docs():
 
     from .renderer_gmsh.gmsh_utils import Vec3DArray
     from .renderer_gmsh.gmsh_renderer import QGmshRenderer
+
+    from .renderer_qtcad.qtcad_renderer import QQTCADRenderer
+    from .renderer_qtcad.qtcad_base import QtcadConstants
 
     from .renderer_ansys_pyaedt.pyaedt_base import QPyaedt
     from .renderer_ansys_pyaedt.q3d_renderer_aedt import QQ3DPyaedt

--- a/qiskit_metal/renderers/renderer_qtcad/qtcad_base.py
+++ b/qiskit_metal/renderers/renderer_qtcad/qtcad_base.py
@@ -1,0 +1,30 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class QtcadInputParams:
+    gmsh_physical_groups: dict
+    _conductors: dict
+    _inductive_ports: dict
+    sample_holder: bool
+    qtcad_options: dict
+    cap_refined_mesh_file: str
+    eig_refined_mesh_file: str
+    eig_field_file: str
+
+
+class QtcadConstants:
+    DEFAULT_JSON_FILENAME = "qtcad_data.json"
+    """Default file name for `QQTCADRenderer`’s associated JSON file."""
+
+    QISKIT_CAPACITANCE_SCALE = 1e-15
+    """Capacitance scale/units in Qiskit Metal"""
+
+    QTCAD_CAP_OUTPUT_FILENAME = "qtcad_output_cap.pickle"
+    """Default file name for QTCAD’s wrapper capacitance pickle file."""
+
+    QTCAD_EIG_OUTPUT_FILENAME = "qtcad_output_eigs.pickle"
+    """Default file name for QTCAD’s wrapper eigenmode pickle file."""
+
+    EIGENMODE_LAYER_TEMPLATE = "abs(electric field) [V/m] - mode {n}"
+    """Template string for QTCAD’s eigenmode scalar layers in VTU files."""

--- a/qiskit_metal/renderers/renderer_qtcad/qtcad_renderer.py
+++ b/qiskit_metal/renderers/renderer_qtcad/qtcad_renderer.py
@@ -23,18 +23,12 @@ import re
 import pyvista as pv
 import shapely
 
+from .qtcad_base import QtcadInputParams, QtcadConstants
 from qiskit_metal import Dict, draw
 from qiskit_metal.toolbox_metal.parsing import parse_entry
 from qiskit_metal.renderers.renderer_base import QRendererAnalysis
 from qiskit_metal.renderers.renderer_gmsh.gmsh_renderer import QGmshRenderer
 from qiskit_metal.designs import MultiPlanar
-
-QISKIT_CAPACITANCE_SCALE = 1e-15
-JSON_FILENAME = "qtcad_data.json"
-QTCAD_CAP_OUTPUT_FILENAME = "qtcad_output_cap.pickle"
-QTCAD_EIG_OUTPUT_FILENAME = "qtcad_output_eigs.pickle"
-# Template string for QTCAD’s eigenmode scalar layers.
-EIGENMODE_LAYER_TEMPLATE = "abs(electric field) [V/m] - mode {n}"
 
 
 def sanitize_string(string: str) -> str:
@@ -188,6 +182,9 @@ class QQTCADRenderer(QRendererAnalysis):
 
         self.mesh_file = None
         self.json_filepath = None
+        self.cap_refined_mesh_file = None
+        self.eig_refined_mesh_file = None
+        self.eig_field_file = None
 
         # If not using adaptive meshing, set adaptive parameters to None.
         # FIXME In the future, it would be desirable to have a flag in the
@@ -846,7 +843,8 @@ class QQTCADRenderer(QRendererAnalysis):
         self._validate_options()
 
         if json_filepath is None:
-            json_filepath = Path(self._options["output_dir"]) / JSON_FILENAME
+            json_filepath = Path(self._options["output_dir"]
+                                ) / QtcadConstants.DEFAULT_JSON_FILENAME
 
         self.json_filepath = json_filepath
 
@@ -858,6 +856,9 @@ class QQTCADRenderer(QRendererAnalysis):
             "qtcad_options": {
                 k: v for k, v in self._options.items() if k != "materials"
             },
+            "cap_refined_mesh_file": None,
+            "eig_refined_mesh_file": None,
+            "eig_field_file": None,
         }
 
         # Guarantee the path to the JSON file exists.
@@ -892,7 +893,7 @@ class QQTCADRenderer(QRendererAnalysis):
         """Calls wrapper file in a specific environment
 
             Args:
-                solve_for (str): Solve for `cap` (capacitance matrix) or `eigs`
+                solve_for (str): Solve for `"cap"` (capacitance matrix) or `"eigs"`
                   (Maxwell eigenmodes).
                 json_filepath (str): Path to the necessary parameters for the solver.
                   Defaults to the value used when exporting them using
@@ -961,6 +962,55 @@ class QQTCADRenderer(QRendererAnalysis):
 
         process.wait()
 
+        # Load additional data from QTCAD’s eigenmode solver.
+        self._load_post_simulation_data(solve_for, json_filepath)
+
+    def _load_post_simulation_data(
+        self,
+        solver: str,
+        json_filepath: str | Path,
+    ) -> None:
+        """Load specific post-simulation data from QTCAD’s solvers.
+
+        QTCAD’s capacitance and Maxwell eigenmode solvers store additional data
+        associated to field (eigenmode only) and refined mesh (capacitance and
+        eigenmode) files after simulations are run. These data are useful for
+        additional analyses.
+
+        Args:
+            solver (str): Which solver to load the associated post-simulation data.
+                Should be `"cap"` (capacitance matrix) or `"eigs"` (Maxwell eigenmodes).
+            json_filepath (str): Path to JSON file with post-simulation data written by
+                QTCAD’s wrapper.
+        """
+
+        with open(json_filepath) as f:
+            json_data = json.load(f)
+
+        validated = QtcadInputParams(**json_data)
+        error_msg_template = ("Unable to load post-simulation data from QTCAD’s"
+                              " {solver} solver.")
+        if solver == "eigs":
+            self.eig_refined_mesh_file = validated.eig_refined_mesh_file
+            self.eig_field_file = validated.eig_field_file
+            if None in (self.eig_refined_mesh_file, self.eig_field_file):
+                error_msg = ValueError(
+                    error_msg_template.format(solver="eigenmode"))
+                self.logger.error(error_msg)
+                raise error_msg
+            self.eig_refined_mesh_file = Path(
+                validated.eig_refined_mesh_file).resolve()
+            self.eig_field_file = Path(validated.eig_field_file).resolve()
+        elif solver == "cap":
+            self.cap_refined_mesh_file = validated.cap_refined_mesh_file
+            if self.cap_refined_mesh_file is None:
+                error_msg = ValueError(
+                    error_msg_template.format(solver="capacitance"))
+                self.logger.error(error_msg)
+                raise error_msg
+            self.cap_refined_mesh_file = Path(
+                validated.cap_refined_mesh_file).resolve()
+
     def load_qtcad_capacitance_matrix(self, filepath: Union[str, None] = None) -> pd.DataFrame:
         """Load capacitance matrix from file.
 
@@ -973,7 +1023,8 @@ class QQTCADRenderer(QRendererAnalysis):
             pd.DataFrame: Table containing the capacitance matrix.
         """
         if filepath is None:
-            filepath = Path(self._options["output_dir"]) / QTCAD_CAP_OUTPUT_FILENAME
+            filepath = Path(self._options["output_dir"]
+                           ) / QtcadConstants.QTCAD_CAP_OUTPUT_FILENAME
 
         input_file = Path(filepath)
         if not input_file.exists():
@@ -1015,7 +1066,8 @@ class QQTCADRenderer(QRendererAnalysis):
             nd.ndarray: Ordered list of Maxwell eigenmodes.
         """
         if filepath is None:
-            filepath = Path(self._options["output_dir"]) / QTCAD_EIG_OUTPUT_FILENAME
+            filepath = Path(self._options["output_dir"]
+                           ) / QtcadConstants.QTCAD_EIG_OUTPUT_FILENAME
 
         input_file = Path(filepath)
         if not input_file.exists():
@@ -1037,25 +1089,19 @@ class QQTCADRenderer(QRendererAnalysis):
 
     def plot_eigenmodes(
         self,
-        vtu_file: str,
-        num_modes: Union[int, None] = None,
         cmap: str = "magma",
         log: bool = True,
         show: bool = True,
         save: bool = False,
-    ) -> Union[str, None]:
+        vtu_file: str | Path | None = None,
+        num_modes: int | None = None,
+    ) -> Path | None:
         """Plot a grid with z=0 slices of all the eigenmodes stored in a VTU file.
 
         PyVista is used to generate the plots of the absolute value of the electric
         field associated to different Maxwell eigenmodes.
 
         Args:
-            vtu_file (str): Path to the VTU file containing QTCAD’s electromagnetic
-                fields.
-            num_modes (Union[int, None], optional): The number of modes to plot,
-                starting from the first one. Defaults to `None`, which plots all modes.
-                However, if loading a VTU file from a different simulation, it must be
-                set accordingly.
             cmap (str, optional): Name of the colour map to be used. Must be a colour
                 map supported by PyVista. Defaults to `"magma"`.
             log (bool, optional): Whether to use a logarithmic scale when mapping data
@@ -1064,10 +1110,19 @@ class QQTCADRenderer(QRendererAnalysis):
                 Defaults to `True`.
             save (bool, optional): Whether to save the plot of the electric fields as a
                 PNG file. Defaults to `True`.
+            vtu_file (str | Path | None): Path to a VTU file containing QTCAD’s
+                electromagnetic fields. If `None`, will automatically consider the VTU
+                file generated by the current `QQTCADRenderer` set up. Must be passed
+                only if loading results from a different simulation set up.
+            num_modes (int | None, optional): The number of modes to plot,
+                starting from the first one. Defaults to `None`, which plots all modes
+                based on the current `QQTCADRenderer` set up. However, if loading a VTU
+                file from a different simulation by passing `vtu_file`, it must be set
+                accordingly.
 
         Returns:
-            Union[str, None]: `str` with the path to the exported image file if `save`
-                was enabled. Otherwise, `None`.
+            Path | None: Path to the exported image file if `save` was enabled.
+                Otherwise, `None`.
         """
 
         if num_modes is None:
@@ -1076,7 +1131,10 @@ class QQTCADRenderer(QRendererAnalysis):
             else:
                 num_modes = self._options.maxwell_emode_raw["num_modes"]
 
-        input_file_path = Path(vtu_file)
+        if vtu_file is None:
+            input_file_path = Path(self.eig_field_file)
+        else:
+            input_file_path = Path(vtu_file)
         output_file = None
 
         # Selectively load the relevant arrays from the VTU file.
@@ -1087,7 +1145,8 @@ class QQTCADRenderer(QRendererAnalysis):
         # Enable the eigenmode-specific arrays and ingest the file.
         # TODO: Verify if the VTU file has all the layers.
         for mdx in range(num_modes):
-            reader.enable_point_array(EIGENMODE_LAYER_TEMPLATE.format(n=mdx))
+            reader.enable_point_array(
+                QtcadConstants.EIGENMODE_LAYER_TEMPLATE.format(n=mdx))
         mesh = reader.read()
 
         # Maximum number of axes along the horizontal direction.
@@ -1108,7 +1167,8 @@ class QQTCADRenderer(QRendererAnalysis):
         for vdx in range(num_axes_v):
             for hdx in range(len(modes_wrapped[vdx])):
                 mdx = modes_wrapped[vdx][hdx]
-                scalar_layer = EIGENMODE_LAYER_TEMPLATE.format(n=mdx)
+                scalar_layer = QtcadConstants.EIGENMODE_LAYER_TEMPLATE.format(
+                    n=mdx)
                 title = f"Eigenmode {mdx+1}"
 
                 # Create slice at z=0.
@@ -1140,7 +1200,7 @@ class QQTCADRenderer(QRendererAnalysis):
         if show:
             plotter.show()
         if save:
-            output_file = input_file_path.with_suffix(".png")
+            output_file = input_file_path.with_suffix(".png").resolve()
             plotter.screenshot(
                 output_file.resolve(),
                 transparent_background=False,
@@ -1149,25 +1209,23 @@ class QQTCADRenderer(QRendererAnalysis):
 
         del mesh
 
-        return str(output_file.resolve())
+        return output_file
 
     def plot_eigenmode(
         self,
-        vtu_file: str,
         n: int = 1,
         cmap: str = "magma",
         log: bool = True,
         show: bool = True,
         save: bool = False,
-    ) -> Union[str, None]:
+        vtu_file: str | Path | None = None,
+    ) -> Path | None:
         """Plot the z=0 slice of a given eigenmode stored in a VTU file.
 
         PyVista is used to generate the plot of the absolute value of the electric
         field associated to the desired Maxwell eigenmode.
 
         Args:
-            vtu_file (str): Path to the VTU file containing QTCAD’s electromagnetic
-                fields.
             n (int): Index of the desired eigenmode. Indexing starts from 1, the ground
                 state.
             cmap (str, optional): Name of the colour map to be used. Must be a colour
@@ -1178,13 +1236,21 @@ class QQTCADRenderer(QRendererAnalysis):
                 Defaults to `True`.
             save (bool, optional): Whether to save the plot of the electric field as a
                 PNG file. Defaults to `True`.
+            vtu_file (str | Path | None): Path to a VTU file containing QTCAD’s
+                electromagnetic fields. If `None`, will automatically consider the VTU
+                file generated by the current `QQTCADRenderer` set up. Must be passed
+                only if loading results from a different simulation set up.
 
         Returns:
             Union[str, None]: `str` with the path to the exported image file if `save`
                 was enabled. Otherwise, `None`.
         """
 
-        input_file_path = Path(vtu_file)
+        if vtu_file is None:
+            input_file_path = Path(self.eig_field_file)
+        else:
+            input_file_path = Path(vtu_file)
+        output_file = None
         title = f"Eigenmode {n}"
         window_size = (1000, 1000)
 
@@ -1195,7 +1261,7 @@ class QQTCADRenderer(QRendererAnalysis):
         reader.disable_all_cell_arrays()
         # Enable the specific eigenmode array and ingest the file.
         mdx = n - 1
-        scalar_layer = EIGENMODE_LAYER_TEMPLATE.format(n=mdx)
+        scalar_layer = QtcadConstants.EIGENMODE_LAYER_TEMPLATE.format(n=mdx)
         reader.enable_point_array(scalar_layer)
         mesh = reader.read()
 
@@ -1230,9 +1296,9 @@ class QQTCADRenderer(QRendererAnalysis):
             plotter.show()
         if save:
             sanitized_layer_name = sanitize_string(
-                EIGENMODE_LAYER_TEMPLATE.format(n=mdx + 1))
+                QtcadConstants.EIGENMODE_LAYER_TEMPLATE.format(n=mdx + 1))
             output_file = input_file_path.with_name(
-                f"{input_file_path.stem}-{sanitized_layer_name}.png")
+                f"{input_file_path.stem}-{sanitized_layer_name}.png").resolve()
             plotter.screenshot(
                 output_file.resolve(),
                 window_size=window_size,
@@ -1244,4 +1310,4 @@ class QQTCADRenderer(QRendererAnalysis):
 
         del mesh
 
-        return str(output_file.resolve())
+        return output_file

--- a/qiskit_metal/renderers/renderer_qtcad/qtcad_renderer.py
+++ b/qiskit_metal/renderers/renderer_qtcad/qtcad_renderer.py
@@ -972,16 +972,16 @@ class QQTCADRenderer(QRendererAnalysis):
     ) -> None:
         """Load specific post-simulation data from QTCAD’s solvers.
 
-        QTCAD’s capacitance and Maxwell eigenmode solvers store additional data
-        associated to field (eigenmode only) and refined mesh (capacitance and
-        eigenmode) files after simulations are run. These data are useful for
-        additional analyses.
+        QTCAD’s capacitance and Maxwell eigenmode solvers register additional data
+        associated to electromagnetic field (eigenmode only) and refined mesh
+        (capacitance and eigenmode) files after simulations are run. These data are
+        useful for additional analyses.
 
         Args:
             solver (str): Which solver to load the associated post-simulation data.
                 Should be `"cap"` (capacitance matrix) or `"eigs"` (Maxwell eigenmodes).
             json_filepath (str): Path to JSON file with post-simulation data written by
-                QTCAD’s wrapper.
+                the wrapper around QTCAD.
         """
 
         with open(json_filepath) as f:

--- a/qiskit_metal/renderers/renderer_qtcad/wrapper.py
+++ b/qiskit_metal/renderers/renderer_qtcad/wrapper.py
@@ -5,10 +5,12 @@ import numpy as np
 import sys
 import logging
 import pickle
+from copy import deepcopy
 
 logging.basicConfig()
 logger = logging.getLogger("qtcad")
 
+from qtcad_base import QtcadInputParams, QtcadConstants
 from qtcad.device import Device as qtcad_device
 from qtcad.device.mesh3d import Mesh as qtcad_mesh
 from qtcad.device import materials as qtcad_materials
@@ -17,37 +19,24 @@ from qtcad.device.capacitance import SolverParams as QtcadSolverCapParams
 from qtcad.device.maxwell_eigenmode import Solver as QtcadSolverEig
 from qtcad.device.maxwell_eigenmode import SolverParams as QtcadSolverEigParams
 
-from dataclasses import dataclass
-
-QISKIT_CAPACITANCE_SCALE = 1e-15
-
-QTCAD_CAP_OUTPUT_FILENAME = "qtcad_output_cap.pickle"
-QTCAD_EIG_OUTPUT_FILENAME = "qtcad_output_eigs.pickle"
-
-@dataclass
-class QTCADInputParams:
-
-    gmsh_physical_groups: dict
-    _conductors: dict
-    _inductive_ports: dict
-    sample_holder: bool
-    qtcad_options: dict
-
 
 class QQTCADWrapper():
 
     name = "qtcad"
 
-    def __init__(self, json_data=None):
+    def __init__(self, json_file: None | str | Path = None) -> None:
         """
         Args:
-            json_data : Parameters imported from QQTCADRenderer.
+            json_file (None|str|Path) : File path to the JSON file with the parameters
+            from `QQTCADRenderer`. If `None`, will use its default value
+            `"qtcad_data.json"`.
         """
 
-        if json_data is None:
-            json_data = "qtcad_data.json"
+        if json_file is None:
+            json_file = QtcadConstants.DEFAULT_JSON_FILENAME
 
-        self.json_data = json_data
+        self.json_file = json_file
+        self.json_data = None
         self.gmsh_physical_groups = None
         self._conductors = None
         self._inductive_ports = None
@@ -56,10 +45,11 @@ class QQTCADWrapper():
 
     def load_and_validate(self):
 
-        with open(self.json_data) as f:
-            data = json.load(f)
+        with open(self.json_file) as f:
+            self.json_data = json.load(f)
 
-        validated = QTCADInputParams(**data)
+        # Work with a copy, as we need the original serializable data.
+        validated = QtcadInputParams(**deepcopy(self.json_data))
         self.gmsh_physical_groups = validated.gmsh_physical_groups
         self._conductors = validated._conductors
         self._inductive_ports = validated._inductive_ports
@@ -67,6 +57,34 @@ class QQTCADWrapper():
         self._options = validated.qtcad_options
 
         self._options["materials"] = dict(substrate=qtcad_materials.Si,)
+
+    def update_json(self, solver_data: dict) -> None:
+        """Update already-existing entries of the original input JSON data file.
+
+        Args:
+            solver_data (dict): Dictionary with the entries to be updated. It must be
+                serializable.
+        """
+
+        # Check if the keys to be updated are a valid subset of the possible fields.
+        if not solver_data.keys() <= self.json_data.keys():
+            error_msg = ValueError("Invalid (superfluous) data found when trying to"
+                                   " update JSON data.")
+            logger.error(error_msg)
+            raise error_msg
+
+        # Check if the data-to-be-updated is serializable.
+        try:
+            _ = json.dumps(solver_data)
+        except (TypeError, OverflowError):
+            error_msg = ValueError("Invalid (non-serializable) input data.")
+            logger.error(error_msg)
+            raise error_msg
+
+        self.json_data.update(solver_data)
+
+        with open(self.json_file, "w") as f:
+            json.dump(self.json_data, f, indent=2)
 
     def setup(self, bnd_conditions) -> None:
         """Set up QTCAD.
@@ -218,6 +236,9 @@ class QQTCADWrapper():
             corresponding field finding methods such as `device.e_field`.
         """
 
+        refined_mesh_file = None
+        field_file = None
+
         # Instantiate SolverParams and load common attributes from the `_options`
         # attribute.
         options_maxwell_emode = self._options["maxwell_emode"]
@@ -228,7 +249,8 @@ class QQTCADWrapper():
             # Reduced set of parameters.
             solver_params_eig.num_modes = options_maxwell_emode["num_modes"]
             solver_params_eig.tol_rel = options_maxwell_emode["tol_rel"]
-            solver_params_eig.min_converged_iters = options_maxwell_emode["min_converged_iters"]
+            solver_params_eig.min_converged_iters = options_maxwell_emode[
+                "min_converged_iters"]
         else:
             # Pass parameters directly to `qtcad.device.maxwell_eigenmode.SolverParams`.
             solver_params_eig = QtcadSolverEigParams(options_maxwell_emode_raw)
@@ -247,6 +269,15 @@ class QQTCADWrapper():
 
         # Solve.
         qtcad_solver_eigs.solve()
+
+        # Update JSON data from post-simulation solver attributes.
+        if len(qtcad_solver_eigs.refined_mesh_files) > 0:
+            refined_mesh_file = qtcad_solver_eigs.refined_mesh_files[-1]
+        if ".vtu" in str(qtcad_solver_eigs.field_files[-1][0]):
+            field_file = qtcad_solver_eigs.field_files[-1][0]
+        solver_data = dict(eig_refined_mesh_file=str(refined_mesh_file),
+                           eig_field_file=str(field_file))
+        self.update_json(solver_data)
 
     def get_energy_e(self):
         """Finds the total electric energy in the device from the electric field.
@@ -387,15 +418,22 @@ class QQTCADWrapper():
         """
 
         qtcad_solver = QtcadSolverCap(
-            self.device, self.signal_conductors, self.solver_params_cap, geo_file=self._options["geo_filepath"]
+            self.device, self.signal_conductors, self.solver_params_cap, geo_file = self._options[
+                "geo_filepath"]
         )
 
         # dict[tuple[str,str], float]
         cap_out = qtcad_solver.solve()
 
+        # Update JSON data from post-simulation solver attributes.
+        if len(qtcad_solver.refined_mesh_files) > 0:
+            refined_mesh_file = qtcad_solver.refined_mesh_files[-1]
+        solver_data = dict(cap_refined_mesh_file=str(refined_mesh_file))
+        self.update_json(solver_data)
+
         for cap in cap_out.keys():
             # Scale capacitance to femtofarads.
-            cap_out[cap] /= QISKIT_CAPACITANCE_SCALE
+            cap_out[cap] /= QtcadConstants.QISKIT_CAPACITANCE_SCALE
             # Convert np.float64 to float to avoid issues with pickle files.
             # See https://github.com/numpy/numpy/issues/24844
             # FIXME: When Qiskit Metal updates to Numpy >2, this can be removed.
@@ -404,15 +442,16 @@ class QQTCADWrapper():
         return cap_out
 
 
-def main_solve_cap(json_data):
+def main_solve_cap(json_file):
 
-    qtcad_wrapper = QQTCADWrapper(json_data=json_data)
+    qtcad_wrapper = QQTCADWrapper(json_file=json_file)
     qtcad_wrapper.load_and_validate()
     qtcad_wrapper.setup("Dirichlet")
 
     qtcad_wrapper.solve_cap()
-    # Save results as a pickle file to be ingested by the QQTCADRenderer.
-    filepath = Path(qtcad_wrapper._options["output_dir"]) / QTCAD_CAP_OUTPUT_FILENAME
+    # Save results as a pickle file to be ingested by `QQTCADRenderer`.
+    filepath = Path(qtcad_wrapper._options["output_dir"]
+                   ) / QtcadConstants.QTCAD_CAP_OUTPUT_FILENAME
     filepath.parent.resolve().mkdir(exist_ok=True, parents=True)
     with open(filepath, 'wb') as file_handle:
         pickle.dump(qtcad_wrapper.capacitance_matrix,
@@ -420,16 +459,18 @@ def main_solve_cap(json_data):
                     protocol=pickle.HIGHEST_PROTOCOL)
 
 
-def main_solve_eigs(json_data):
+def main_solve_eigs(json_file):
 
-    qtcad_wrapper = QQTCADWrapper(json_data=json_data)
+    qtcad_wrapper = QQTCADWrapper(json_file=json_file)
     qtcad_wrapper.load_and_validate()
     qtcad_wrapper.setup("PEC")
 
     qtcad_wrapper.solve_eigs()
 
-    Path(qtcad_wrapper._options["output_dir"]).resolve().mkdir(exist_ok=True, parents=True)
-    filepath = Path(qtcad_wrapper._options["output_dir"]) / QTCAD_EIG_OUTPUT_FILENAME
+    Path(qtcad_wrapper._options["output_dir"]).resolve().mkdir(exist_ok=True,
+                                                               parents=True)
+    filepath = Path(qtcad_wrapper._options["output_dir"]
+                   ) / QtcadConstants.QTCAD_EIG_OUTPUT_FILENAME
 
     with open(filepath, 'wb') as file_handle:
         pickle.dump(qtcad_wrapper.device.maxwell_freqs.tolist(),
@@ -443,12 +484,12 @@ if __name__ == "__main__":
         sys.exit(1)
 
     solve_for = sys.argv[1]
-    json_data = sys.argv[2]
+    json_file = sys.argv[2]
 
     if solve_for == "cap":
-        main_solve_cap(json_data)
+        main_solve_cap(json_file)
     elif solve_for == "eigs":
-        main_solve_eigs(json_data)
+        main_solve_eigs(json_file)
     else:
         print(f"Wrong quantity to solve for: {solve_for}."
               " Use `cap` for capacitance or `eigs` for Maxwell eigenvalues.")


### PR DESCRIPTION
The path to the VTU file with the fields of a given simulation is now available via `QQTCADRenderer.eig_refined_mesh_file`, which is used by `QQTCAD.plot_eigenmode`*.

Paths to the refined meshes generated by the capacitance and Maxwell eigenmode solvers are also available via `QQTCADRenderer.cap_refined_mesh_file` and `QQTCADRenderer.eig_refined_mesh_file`, respectively.

# Examples of the behaviour

For an eigenmode simulation of two modes of an isolated CPW (a non-accurate one for this test):
```python
>>> qtcad_renderer.eig_refined_mesh_file
PosixPath('.../output/meandered_resonator/qtcad-refined-mesh.msh4')
>>> qtcad_renderer.eig_field_file
PosixPath('.../output/meandered_resonator/qtcad-fields.vtu')
```
Also, `qtcad_renderer.plot_eigenmodes()` would output in a Python notebook
<img width="840" height="574" alt="image" src="https://github.com/user-attachments/assets/956419d8-37ca-475a-9036-9b3d3f695e68" />
<img width="841" height="960" alt="image" src="https://github.com/user-attachments/assets/053f53eb-8970-4931-9e1b-67fdca070870" />

And we would have
```python
>>> png_eigenmodes = qtcad_renderer.plot_eigenmodes(show=False, save=True)
Image saved to ‘.../output/meandered_resonator/qtcad-fields.png’.
>>> png_eigenmodes
PosixPath('.../output/meandered_resonator/qtcad-fields.png')
```
and
```python
>>> png_eigenmode2 = qtcad_renderer.plot_eigenmode(n=2, show=False, save=True)
Image of the eigenmode 2 saved to ‘.../output/meandered_resonator/qtcad-fields-abselectric_field_Vm_-_mode_2.png’.
>>>  png_eigenmode2
PosixPath('.../output/meandered_resonator/qtcad-fields-abselectric_field_Vm_-_mode_2.png')
```

All paths shown were originally absolute ones, I used `...` to shorten them.
