### PR TITLE
Release 2.1.1

### DIFF
--- a/qiskit_metal/renderers/__init__.py
+++ b/qiskit_metal/renderers/__init__.py
@@ -82,6 +82,16 @@ GMSH Renderer
     Vec3DArray
 
 
+QTCAD Renderer
+--------------
+
+.. autosummary::
+    :toctree: ../stubs/
+
+    QQTCADRenderer
+    QtcadConstants
+
+
 
 """
 
@@ -112,6 +122,9 @@ if config.is_building_docs():
 
     from .renderer_gmsh.gmsh_utils import Vec3DArray
     from .renderer_gmsh.gmsh_renderer import QGmshRenderer
+
+    from .renderer_qtcad.qtcad_renderer import QQTCADRenderer
+    from .renderer_qtcad.qtcad_base import QtcadConstants
 
     from .renderer_ansys_pyaedt.pyaedt_base import QPyaedt
     from .renderer_ansys_pyaedt.q3d_renderer_aedt import QQ3DPyaedt

--- a/qiskit_metal/renderers/renderer_gmsh/gmsh_renderer.py
+++ b/qiskit_metal/renderers/renderer_gmsh/gmsh_renderer.py
@@ -1321,12 +1321,12 @@ class QGmshRenderer(QRenderer):
 
     def export_geometry(self, filepath: str):
         """Export the Gmsh geometry as a geo_unrolled, BREP or XAO file.
-        Supported formats: .geo_unrolled, .brep, .xao
+        Supported formats: .geo_unrolled, .xao
 
         Args:
             filepath (str): path of the file to export geometry to
         """
-        valid_file_exts = ["geo_unrolled", "brep", "xao"]
+        valid_file_exts = ["geo_unrolled", "xao"]
         file_ext = filepath.split(".")[-1]
         if file_ext not in valid_file_exts:
             self.logger.error(

--- a/qiskit_metal/renderers/renderer_gmsh/gmsh_renderer.py
+++ b/qiskit_metal/renderers/renderer_gmsh/gmsh_renderer.py
@@ -1349,10 +1349,10 @@ class QGmshRenderer(QRenderer):
                 "you aren't explicitly handling the mesh size fields, we recommend "
                 "to export the geometry before generating the mesh in your design as "
                 "it might interfere with your .geo_unrolled file imports.")
-        elif has_mesh and file_ext == "brep":
+        elif has_mesh and file_ext == "xao":
             self.logger.warning(
                 "WARNING: The existing model contains mesh size field definitions, "
-                "which are not needed when exporting to BREP files for use in "
+                "which are not needed when exporting to XAO files for use in "
                 "renderers that support adaptive meshing refinement (AMR). If you "
                 "are going to use AMR, consider disabling the use of mesh size "
                 "fields.")

--- a/qiskit_metal/renderers/renderer_gmsh/gmsh_renderer.py
+++ b/qiskit_metal/renderers/renderer_gmsh/gmsh_renderer.py
@@ -1320,7 +1320,7 @@ class QGmshRenderer(QRenderer):
         self.export_geometry(filepath)
 
     def export_geometry(self, filepath: str):
-        """Export the Gmsh geometry as a geo_unrolled, BREP or XAO file.
+        """Export the Gmsh geometry as a geo_unrolled or XAO file.
         Supported formats: .geo_unrolled, .xao
 
         Args:

--- a/qiskit_metal/renderers/renderer_qtcad/qtcad_base.py
+++ b/qiskit_metal/renderers/renderer_qtcad/qtcad_base.py
@@ -1,0 +1,30 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class QtcadInputParams:
+    gmsh_physical_groups: dict
+    _conductors: dict
+    _inductive_ports: dict
+    sample_holder: bool
+    qtcad_options: dict
+    cap_refined_mesh_file: str
+    eig_refined_mesh_file: str
+    eig_field_file: str
+
+
+class QtcadConstants:
+    DEFAULT_JSON_FILENAME = "qtcad_data.json"
+    """Default file name for `QQTCADRenderer`’s associated JSON file."""
+
+    QISKIT_CAPACITANCE_SCALE = 1e-15
+    """Capacitance scale/units in Qiskit Metal"""
+
+    QTCAD_CAP_OUTPUT_FILENAME = "qtcad_output_cap.pickle"
+    """Default file name for QTCAD’s wrapper capacitance pickle file."""
+
+    QTCAD_EIG_OUTPUT_FILENAME = "qtcad_output_eigs.pickle"
+    """Default file name for QTCAD’s wrapper eigenmode pickle file."""
+
+    EIGENMODE_LAYER_TEMPLATE = "abs(electric field) [V/m] - mode {n}"
+    """Template string for QTCAD’s eigenmode scalar layers in VTU files."""

--- a/qiskit_metal/renderers/renderer_qtcad/qtcad_base.py
+++ b/qiskit_metal/renderers/renderer_qtcad/qtcad_base.py
@@ -21,10 +21,10 @@ class QtcadConstants:
     """Capacitance scale/units in Qiskit Metal"""
 
     QTCAD_CAP_OUTPUT_FILENAME = "qtcad_output_cap.pickle"
-    """Default file name for QTCAD’s wrapper capacitance pickle file."""
+    """Default file name for the pickle file with capacitance results."""
 
     QTCAD_EIG_OUTPUT_FILENAME = "qtcad_output_eigs.pickle"
-    """Default file name for QTCAD’s wrapper eigenmode pickle file."""
+    """Default file name for the pickle file with Maxwell eigenmode results."""
 
     EIGENMODE_LAYER_TEMPLATE = "abs(electric field) [V/m] - mode {n}"
-    """Template string for QTCAD’s eigenmode scalar layers in VTU files."""
+    """Template string for QTCAD®’s Maxwell eigenmode scalar layers in VTU files."""

--- a/qiskit_metal/renderers/renderer_qtcad/qtcad_renderer.py
+++ b/qiskit_metal/renderers/renderer_qtcad/qtcad_renderer.py
@@ -18,6 +18,8 @@ import numpy as np
 import pandas as pd
 import json
 import pickle
+import re
+import pyvista as pv
 
 from qiskit_metal import Dict, draw
 from qiskit_metal.renderers.renderer_base import QRendererAnalysis
@@ -28,8 +30,16 @@ QISKIT_CAPACITANCE_SCALE = 1e-15
 JSON_FILENAME = "qtcad_data.json"
 QTCAD_CAP_OUTPUT_FILENAME = "qtcad_output_cap.pickle"
 QTCAD_EIG_OUTPUT_FILENAME = "qtcad_output_eigs.pickle"
+# Template string for QTCAD’s eigenmode scalar layers.
+EIGENMODE_LAYER_TEMPLATE = "abs(electric field) [V/m] - mode {n}"
 
 
+def sanitize_string(string: str) -> str:
+    """Remove a string’s non-alphanumeric characters/spaces/underscores/hyphens.
+    """
+    filename = re.sub(r'[^\w\s\-_.]', '', string)
+    filename = filename.replace(' ', '_')
+    return filename
 
 class QQTCADRenderer(QRendererAnalysis):
     """Extends QRendererAnalysis class to use QTCAD’s API with Gmsh’s meshes.
@@ -876,3 +886,174 @@ class QQTCADRenderer(QRendererAnalysis):
 
         return frequencies / 1e9
 
+        """Plot slices of all the eigenmodes stored in a VTU file on a grid.
+
+        Args
+            TODO
+    def plot_eigenmodes(
+        self,
+        vtu_file: str,
+        num_modes: Union[int, None] = None,
+        cmap: str = "magma",
+        log: bool = True,
+        show: bool = True,
+        save: bool = False,
+    ) -> Union[str, None]:
+        """
+
+        if num_modes is None:
+            if self._options.maxwell_emode_raw is None:
+                num_modes = self._options.maxwell_emode["num_modes"]
+            else:
+                num_modes = self._options.maxwell_emode_raw["num_modes"]
+
+        input_file_path = Path(vtu_file)
+        output_file = None
+
+        # Selectively load the relevant arrays from the VTU file.
+        reader = pv.get_reader(input_file_path)
+        # Disable all arrays.
+        reader.disable_all_point_arrays()
+        reader.disable_all_cell_arrays()
+        # Enable the eigenmode-specific arrays and ingest the file.
+        # TODO: Verify if the VTU file has all the layers.
+        for mdx in range(num_modes):
+            reader.enable_point_array(EIGENMODE_LAYER_TEMPLATE.format(n=mdx))
+        mesh = reader.read()
+
+        # Maximum number of axes along the horizontal direction.
+        num_axes_h = 2
+        # Wrap the list with the indices to the eigenmodes and get the
+        # resulting list’s length. This is the desired number of axes along
+        # the vertical direction.
+        modes_wrapped = [
+            list(range(num_modes))[i:i + num_axes_h]
+            for i in range(0, num_modes, num_axes_h)
+        ]
+        num_axes_v = len(modes_wrapped)
+
+        # Set up the plot.
+        window_size = (500 * num_axes_h, 500 * num_axes_v)
+        plotter = pv.Plotter(shape=(num_axes_v, num_axes_h),
+                             window_size=window_size)
+        for vdx in range(num_axes_v):
+            for hdx in range(len(modes_wrapped[vdx])):
+                mdx = modes_wrapped[vdx][hdx]
+                scalar_layer = EIGENMODE_LAYER_TEMPLATE.format(n=mdx)
+                title = f"Eigenmode {mdx+1}"
+
+                # Create slice at z=0.
+                sliced_data = mesh.slice(normal='z', origin=(0, 0, 0))
+
+                plotter.subplot(vdx, hdx)
+                # Add the sliced data.
+                plotter.add_mesh(
+                    sliced_data,
+                    scalars=scalar_layer,
+                    log_scale=log,
+                    cmap=cmap,
+                    # Disable the scalar bar to add a customized one later.
+                    show_scalar_bar=False,
+                )
+                plotter.add_title(title, font_size=11)
+                # Add a custom scalar bar.
+                plotter.add_scalar_bar(
+                    title=f"|E| (V/m), mode {mdx+1}",
+                    position_x=0.15,
+                    position_y=0.05,
+                    width=0.7,
+                    height=0.1,
+                    label_font_size=10,
+                )
+                # Make sure the x-y plane is visible.
+                plotter.view_xy()
+
+        if show:
+            plotter.show()
+        if save:
+            output_file = input_file_path.with_suffix(".png")
+            plotter.screenshot(
+                output_file.resolve(),
+                transparent_background=False,
+            )
+            print(f"Image saved to ‘{output_file.resolve()}’.")
+
+        del mesh
+
+        """Plot a slice at z=0 of a given eigenmode stored in a VTU file.
+        return str(output_file.resolve())
+
+        Args
+            TODO
+    def plot_eigenmode(
+        self,
+        vtu_file: str,
+        n: int = 1,
+        cmap: str = "magma",
+        log: bool = True,
+        show: bool = True,
+        save: bool = False,
+    ) -> Union[str, None]:
+        """
+
+        input_file_path = Path(vtu_file)
+        title = f"Eigenmode {n}"
+        window_size = (1000, 1000)
+
+        # Selectively load the relevant arrays from the VTU file.
+        reader = pv.get_reader(input_file_path)
+        # Disable all arrays.
+        reader.disable_all_point_arrays()
+        reader.disable_all_cell_arrays()
+        # Enable the specific eigenmode array and ingest the file.
+        mdx = n - 1
+        scalar_layer = EIGENMODE_LAYER_TEMPLATE.format(n=mdx)
+        reader.enable_point_array(scalar_layer)
+        mesh = reader.read()
+
+        # Create slice at z=0.
+        sliced_data = mesh.slice(normal='z', origin=(0, 0, 0))
+
+        # Set up the plot.
+        plotter = pv.Plotter(window_size=window_size)
+        # Add the sliced data.
+        plotter.add_mesh(
+            sliced_data,
+            scalars=scalar_layer,
+            log_scale=log,
+            cmap=cmap,
+            # Disable the scalar bar to add a customized one later.
+            show_scalar_bar=False,
+        )
+        plotter.add_title(title, font_size=11)
+        # Add a custom scalar bar.
+        plotter.add_scalar_bar(
+            title=f"|E| (V/m), mode {mdx+1}",
+            position_x=0.15,
+            position_y=0.05,
+            width=0.7,
+            height=0.1,
+            label_font_size=10,
+        )
+        # Make sure the x-y plane is visible.
+        plotter.view_xy()
+
+        if show:
+            plotter.show()
+        if save:
+            sanitized_layer_name = sanitize_string(
+                EIGENMODE_LAYER_TEMPLATE.format(n=mdx + 1))
+            output_file = input_file_path.with_name(
+                f"{input_file_path.stem}-{sanitized_layer_name}.png")
+            plotter.screenshot(
+                output_file.resolve(),
+                window_size=window_size,
+                transparent_background=False,
+            )
+            print(
+                f"Image of the eigenmode {n} saved to ‘{output_file.resolve()}’."
+            )
+
+        del mesh
+
+        return str(output_file.resolve())

--- a/qiskit_metal/renderers/renderer_qtcad/qtcad_renderer.py
+++ b/qiskit_metal/renderers/renderer_qtcad/qtcad_renderer.py
@@ -23,18 +23,12 @@ import re
 import pyvista as pv
 import shapely
 
+from .qtcad_base import QtcadInputParams, QtcadConstants
 from qiskit_metal import Dict, draw
 from qiskit_metal.toolbox_metal.parsing import parse_entry
 from qiskit_metal.renderers.renderer_base import QRendererAnalysis
 from qiskit_metal.renderers.renderer_gmsh.gmsh_renderer import QGmshRenderer
 from qiskit_metal.designs import MultiPlanar
-
-QISKIT_CAPACITANCE_SCALE = 1e-15
-JSON_FILENAME = "qtcad_data.json"
-QTCAD_CAP_OUTPUT_FILENAME = "qtcad_output_cap.pickle"
-QTCAD_EIG_OUTPUT_FILENAME = "qtcad_output_eigs.pickle"
-# Template string for QTCAD’s eigenmode scalar layers.
-EIGENMODE_LAYER_TEMPLATE = "abs(electric field) [V/m] - mode {n}"
 
 
 def sanitize_string(string: str) -> str:
@@ -188,6 +182,9 @@ class QQTCADRenderer(QRendererAnalysis):
 
         self.mesh_file = None
         self.json_filepath = None
+        self.cap_refined_mesh_file = None
+        self.eig_refined_mesh_file = None
+        self.eig_field_file = None
 
         # If not using adaptive meshing, set adaptive parameters to None.
         # FIXME In the future, it would be desirable to have a flag in the
@@ -846,7 +843,8 @@ class QQTCADRenderer(QRendererAnalysis):
         self._validate_options()
 
         if json_filepath is None:
-            json_filepath = Path(self._options["output_dir"]) / JSON_FILENAME
+            json_filepath = Path(self._options["output_dir"]
+                                ) / QtcadConstants.DEFAULT_JSON_FILENAME
 
         self.json_filepath = json_filepath
 
@@ -858,6 +856,9 @@ class QQTCADRenderer(QRendererAnalysis):
             "qtcad_options": {
                 k: v for k, v in self._options.items() if k != "materials"
             },
+            "cap_refined_mesh_file": None,
+            "eig_refined_mesh_file": None,
+            "eig_field_file": None,
         }
 
         # Guarantee the path to the JSON file exists.
@@ -892,7 +893,7 @@ class QQTCADRenderer(QRendererAnalysis):
         """Calls wrapper file in a specific environment
 
             Args:
-                solve_for (str): Solve for `cap` (capacitance matrix) or `eigs`
+                solve_for (str): Solve for `"cap"` (capacitance matrix) or `"eigs"`
                   (Maxwell eigenmodes).
                 json_filepath (str): Path to the necessary parameters for the solver.
                   Defaults to the value used when exporting them using
@@ -961,6 +962,55 @@ class QQTCADRenderer(QRendererAnalysis):
 
         process.wait()
 
+        # Load additional data from QTCAD’s eigenmode solver.
+        self._load_post_simulation_data(solve_for, json_filepath)
+
+    def _load_post_simulation_data(
+        self,
+        solver: str,
+        json_filepath: str | Path,
+    ) -> None:
+        """Load specific post-simulation data from QTCAD’s solvers.
+
+        QTCAD’s capacitance and Maxwell eigenmode solvers store additional data
+        associated to field (eigenmode only) and refined mesh (capacitance and
+        eigenmode) files after simulations are run. These data are useful for
+        additional analyses.
+
+        Args:
+            solver (str): Which solver to load the associated post-simulation data.
+                Should be `"cap"` (capacitance matrix) or `"eigs"` (Maxwell eigenmodes).
+            json_filepath (str): Path to JSON file with post-simulation data written by
+                QTCAD’s wrapper.
+        """
+
+        with open(json_filepath) as f:
+            json_data = json.load(f)
+
+        validated = QtcadInputParams(**json_data)
+        error_msg_template = ("Unable to load post-simulation data from QTCAD’s"
+                              " {solver} solver.")
+        if solver == "eigs":
+            self.eig_refined_mesh_file = validated.eig_refined_mesh_file
+            self.eig_field_file = validated.eig_field_file
+            if None in (self.eig_refined_mesh_file, self.eig_field_file):
+                error_msg = ValueError(
+                    error_msg_template.format(solver="eigenmode"))
+                self.logger.error(error_msg)
+                raise error_msg
+            self.eig_refined_mesh_file = Path(
+                validated.eig_refined_mesh_file).resolve()
+            self.eig_field_file = Path(validated.eig_field_file).resolve()
+        elif solver == "cap":
+            self.cap_refined_mesh_file = validated.cap_refined_mesh_file
+            if self.cap_refined_mesh_file is None:
+                error_msg = ValueError(
+                    error_msg_template.format(solver="capacitance"))
+                self.logger.error(error_msg)
+                raise error_msg
+            self.cap_refined_mesh_file = Path(
+                validated.cap_refined_mesh_file).resolve()
+
     def load_qtcad_capacitance_matrix(self, filepath: Union[str, None] = None) -> pd.DataFrame:
         """Load capacitance matrix from file.
 
@@ -973,7 +1023,8 @@ class QQTCADRenderer(QRendererAnalysis):
             pd.DataFrame: Table containing the capacitance matrix.
         """
         if filepath is None:
-            filepath = Path(self._options["output_dir"]) / QTCAD_CAP_OUTPUT_FILENAME
+            filepath = Path(self._options["output_dir"]
+                           ) / QtcadConstants.QTCAD_CAP_OUTPUT_FILENAME
 
         input_file = Path(filepath)
         if not input_file.exists():
@@ -1015,7 +1066,8 @@ class QQTCADRenderer(QRendererAnalysis):
             nd.ndarray: Ordered list of Maxwell eigenmodes.
         """
         if filepath is None:
-            filepath = Path(self._options["output_dir"]) / QTCAD_EIG_OUTPUT_FILENAME
+            filepath = Path(self._options["output_dir"]
+                           ) / QtcadConstants.QTCAD_EIG_OUTPUT_FILENAME
 
         input_file = Path(filepath)
         if not input_file.exists():
@@ -1037,25 +1089,19 @@ class QQTCADRenderer(QRendererAnalysis):
 
     def plot_eigenmodes(
         self,
-        vtu_file: str,
-        num_modes: Union[int, None] = None,
         cmap: str = "magma",
         log: bool = True,
         show: bool = True,
         save: bool = False,
-    ) -> Union[str, None]:
+        vtu_file: str | Path | None = None,
+        num_modes: int | None = None,
+    ) -> Path | None:
         """Plot a grid with z=0 slices of all the eigenmodes stored in a VTU file.
 
         PyVista is used to generate the plots of the absolute value of the electric
         field associated to different Maxwell eigenmodes.
 
         Args:
-            vtu_file (str): Path to the VTU file containing QTCAD’s electromagnetic
-                fields.
-            num_modes (Union[int, None], optional): The number of modes to plot,
-                starting from the first one. Defaults to `None`, which plots all modes.
-                However, if loading a VTU file from a different simulation, it must be
-                set accordingly.
             cmap (str, optional): Name of the colour map to be used. Must be a colour
                 map supported by PyVista. Defaults to `"magma"`.
             log (bool, optional): Whether to use a logarithmic scale when mapping data
@@ -1064,10 +1110,19 @@ class QQTCADRenderer(QRendererAnalysis):
                 Defaults to `True`.
             save (bool, optional): Whether to save the plot of the electric fields as a
                 PNG file. Defaults to `True`.
+            vtu_file (str | Path | None): Path to a VTU file containing QTCAD’s
+                electromagnetic fields. If `None`, will automatically consider the VTU
+                file generated by the current `QQTCADRenderer` set up. Must be passed
+                only if loading results from a different simulation set up.
+            num_modes (int | None, optional): The number of modes to plot,
+                starting from the first one. Defaults to `None`, which plots all modes
+                based on the current `QQTCADRenderer` set up. However, if loading a VTU
+                file from a different simulation by passing `vtu_file`, it must be set
+                accordingly.
 
         Returns:
-            Union[str, None]: `str` with the path to the exported image file if `save`
-                was enabled. Otherwise, `None`.
+            Path | None: Path to the exported image file if `save` was enabled.
+                Otherwise, `None`.
         """
 
         if num_modes is None:
@@ -1076,7 +1131,10 @@ class QQTCADRenderer(QRendererAnalysis):
             else:
                 num_modes = self._options.maxwell_emode_raw["num_modes"]
 
-        input_file_path = Path(vtu_file)
+        if vtu_file is None:
+            input_file_path = Path(self.eig_field_file)
+        else:
+            input_file_path = Path(vtu_file)
         output_file = None
 
         # Selectively load the relevant arrays from the VTU file.
@@ -1087,7 +1145,8 @@ class QQTCADRenderer(QRendererAnalysis):
         # Enable the eigenmode-specific arrays and ingest the file.
         # TODO: Verify if the VTU file has all the layers.
         for mdx in range(num_modes):
-            reader.enable_point_array(EIGENMODE_LAYER_TEMPLATE.format(n=mdx))
+            reader.enable_point_array(
+                QtcadConstants.EIGENMODE_LAYER_TEMPLATE.format(n=mdx))
         mesh = reader.read()
 
         # Maximum number of axes along the horizontal direction.
@@ -1108,7 +1167,8 @@ class QQTCADRenderer(QRendererAnalysis):
         for vdx in range(num_axes_v):
             for hdx in range(len(modes_wrapped[vdx])):
                 mdx = modes_wrapped[vdx][hdx]
-                scalar_layer = EIGENMODE_LAYER_TEMPLATE.format(n=mdx)
+                scalar_layer = QtcadConstants.EIGENMODE_LAYER_TEMPLATE.format(
+                    n=mdx)
                 title = f"Eigenmode {mdx+1}"
 
                 # Create slice at z=0.
@@ -1140,7 +1200,7 @@ class QQTCADRenderer(QRendererAnalysis):
         if show:
             plotter.show()
         if save:
-            output_file = input_file_path.with_suffix(".png")
+            output_file = input_file_path.with_suffix(".png").resolve()
             plotter.screenshot(
                 output_file.resolve(),
                 transparent_background=False,
@@ -1149,25 +1209,23 @@ class QQTCADRenderer(QRendererAnalysis):
 
         del mesh
 
-        return str(output_file.resolve())
+        return output_file
 
     def plot_eigenmode(
         self,
-        vtu_file: str,
         n: int = 1,
         cmap: str = "magma",
         log: bool = True,
         show: bool = True,
         save: bool = False,
-    ) -> Union[str, None]:
+        vtu_file: str | Path | None = None,
+    ) -> Path | None:
         """Plot the z=0 slice of a given eigenmode stored in a VTU file.
 
         PyVista is used to generate the plot of the absolute value of the electric
         field associated to the desired Maxwell eigenmode.
 
         Args:
-            vtu_file (str): Path to the VTU file containing QTCAD’s electromagnetic
-                fields.
             n (int): Index of the desired eigenmode. Indexing starts from 1, the ground
                 state.
             cmap (str, optional): Name of the colour map to be used. Must be a colour
@@ -1178,13 +1236,21 @@ class QQTCADRenderer(QRendererAnalysis):
                 Defaults to `True`.
             save (bool, optional): Whether to save the plot of the electric field as a
                 PNG file. Defaults to `True`.
+            vtu_file (str | Path | None): Path to a VTU file containing QTCAD’s
+                electromagnetic fields. If `None`, will automatically consider the VTU
+                file generated by the current `QQTCADRenderer` set up. Must be passed
+                only if loading results from a different simulation set up.
 
         Returns:
             Union[str, None]: `str` with the path to the exported image file if `save`
                 was enabled. Otherwise, `None`.
         """
 
-        input_file_path = Path(vtu_file)
+        if vtu_file is None:
+            input_file_path = Path(self.eig_field_file)
+        else:
+            input_file_path = Path(vtu_file)
+        output_file = None
         title = f"Eigenmode {n}"
         window_size = (1000, 1000)
 
@@ -1195,7 +1261,7 @@ class QQTCADRenderer(QRendererAnalysis):
         reader.disable_all_cell_arrays()
         # Enable the specific eigenmode array and ingest the file.
         mdx = n - 1
-        scalar_layer = EIGENMODE_LAYER_TEMPLATE.format(n=mdx)
+        scalar_layer = QtcadConstants.EIGENMODE_LAYER_TEMPLATE.format(n=mdx)
         reader.enable_point_array(scalar_layer)
         mesh = reader.read()
 
@@ -1230,9 +1296,9 @@ class QQTCADRenderer(QRendererAnalysis):
             plotter.show()
         if save:
             sanitized_layer_name = sanitize_string(
-                EIGENMODE_LAYER_TEMPLATE.format(n=mdx + 1))
+                QtcadConstants.EIGENMODE_LAYER_TEMPLATE.format(n=mdx + 1))
             output_file = input_file_path.with_name(
-                f"{input_file_path.stem}-{sanitized_layer_name}.png")
+                f"{input_file_path.stem}-{sanitized_layer_name}.png").resolve()
             plotter.screenshot(
                 output_file.resolve(),
                 window_size=window_size,
@@ -1244,4 +1310,4 @@ class QQTCADRenderer(QRendererAnalysis):
 
         del mesh
 
-        return str(output_file.resolve())
+        return output_file

--- a/qiskit_metal/renderers/renderer_qtcad/qtcad_renderer.py
+++ b/qiskit_metal/renderers/renderer_qtcad/qtcad_renderer.py
@@ -972,16 +972,16 @@ class QQTCADRenderer(QRendererAnalysis):
     ) -> None:
         """Load specific post-simulation data from QTCAD’s solvers.
 
-        QTCAD’s capacitance and Maxwell eigenmode solvers store additional data
-        associated to field (eigenmode only) and refined mesh (capacitance and
-        eigenmode) files after simulations are run. These data are useful for
-        additional analyses.
+        QTCAD’s capacitance and Maxwell eigenmode solvers register additional data
+        associated to electromagnetic field (eigenmode only) and refined mesh
+        (capacitance and eigenmode) files after simulations are run. These data are
+        useful for additional analyses.
 
         Args:
             solver (str): Which solver to load the associated post-simulation data.
                 Should be `"cap"` (capacitance matrix) or `"eigs"` (Maxwell eigenmodes).
             json_filepath (str): Path to JSON file with post-simulation data written by
-                QTCAD’s wrapper.
+                the wrapper around QTCAD.
         """
 
         with open(json_filepath) as f:

--- a/qiskit_metal/renderers/renderer_qtcad/qtcad_renderer.py
+++ b/qiskit_metal/renderers/renderer_qtcad/qtcad_renderer.py
@@ -46,7 +46,7 @@ def sanitize_string(string: str) -> str:
 
 
 class QQTCADRenderer(QRendererAnalysis):
-    """Extends QRendererAnalysis class to use QTCAD’s API with Gmsh’s meshes.
+    """Extends QRendererAnalysis class to use QTCAD®’s API with Gmsh’s meshes.
     Based on QElmerRenderer.
 
     QQTCADRenderer default options:
@@ -81,7 +81,7 @@ class QQTCADRenderer(QRendererAnalysis):
                 tol_abs is useful when :math:`|C_{ij}|` is expected to be zero or
                 very small.
 
-        * capacitance_raw -- Dictionary of parameters to be passed directly to QTCAD's capacitance
+        * capacitance_raw -- Dictionary of parameters to be passed directly to QTCAD®'s capacitance
                              extractor solver via `qtcad.device.capacitance.SolverParams`.
                              Overwrites the parameters defined in `capacitance`: _any_ parameters
                              from `capacitance` are ignored (see note) and the defaults from
@@ -104,7 +104,7 @@ class QQTCADRenderer(QRendererAnalysis):
                                      results that agree within the tolerance thresholds.
                                      Default: 5.
 
-        * maxwell_emode_raw -- Dictionary of parameters to be passed directly to QTCAD's Maxwell
+        * maxwell_emode_raw -- Dictionary of parameters to be passed directly to QTCAD®'s Maxwell
                                eigenmode extractor solver via
                                `qtcad.device.maxwell_eigenmode.SolverParams`.
                                Overwrites the parameters defined in `maxwell_emode`: _any_
@@ -222,7 +222,7 @@ class QQTCADRenderer(QRendererAnalysis):
         return status
 
     def initialize_renderer(self):
-        """Initializes the Gmsh and QTCAD renderers.
+        """Initializes the Gmsh and QTCAD® renderers.
 
         NOTE TO THE USER: this should be used when using the QQTCADRenderer
         through design.renderers.qtcad instance.
@@ -242,7 +242,7 @@ class QQTCADRenderer(QRendererAnalysis):
         self._qtcad_ready = self.check_environment()
 
     def _initiate_renderer(self):
-        """Initializes the Gmsh renderer and check QTCAD requirements.
+        """Initializes the Gmsh renderer and check QTCAD® requirements.
 
         NOTE: This is automatically called when the USER specifically imports
         QQTCADRenderer in a Jupyter notebook and instantiates it.
@@ -261,7 +261,7 @@ class QQTCADRenderer(QRendererAnalysis):
         return self._close_renderer()
 
     def check_environment(self) -> bool:
-        """Check if QTCAD is able to fully run as a renderer."""
+        """Check if QTCAD® is able to fully run as a renderer."""
 
         return True
 
@@ -809,7 +809,7 @@ class QQTCADRenderer(QRendererAnalysis):
                                   " with the parameters allowed by"
                                   " `qtcad.device.maxwell_eigenmode.SolverParams` or left unset."
                                   " Please check the `options` parameters used to instantiate the"
-                                  " QTCAD renderer.")
+                                  " QTCAD® renderer.")
             self.logger.error(error_msg)
             raise error_msg
         if isinstance(self._options["capacitance_raw"], dict):
@@ -825,7 +825,7 @@ class QQTCADRenderer(QRendererAnalysis):
                                   " dictionary with the parameters allowed by"
                                   " `qtcad.device.maxwell_eigenmode.SolverParams` or left unset."
                                   " Please check the `options` parameters used to instantiate the"
-                                  " QTCAD renderer.")
+                                  " QTCAD® renderer.")
             self.logger.error(error_msg)
             raise error_msg
         if isinstance(self._options["maxwell_emode_raw"], dict):
@@ -837,7 +837,7 @@ class QQTCADRenderer(QRendererAnalysis):
             self.logger.warning(warning_msg)
 
     def export_parameters(self, json_filepath=None):
-        """Exports parameters that are required for QTCAD simulations as a JSON file."""
+        """Exports parameters that are required for QTCAD® simulations as a JSON file."""
 
         # Verify if the simulation parameters are valid.
         self._validate_options()
@@ -898,7 +898,7 @@ class QQTCADRenderer(QRendererAnalysis):
                 json_filepath (str): Path to the necessary parameters for the solver.
                   Defaults to the value used when exporting them using
                   `export_parameters`.
-                env_name (str): name of the conda environment where QTCAD is available.
+                env_name (str): name of the conda environment where QTCAD® is available.
                   Default: qtcad
 
         """
@@ -911,18 +911,18 @@ class QQTCADRenderer(QRendererAnalysis):
         if json_filepath is None:
             raise Exception(
                 "Unable to find the JSON file with the input parameters to run"
-                " QTCAD simulations."
+                " QTCAD® simulations."
                 " Please make sure to have exported them using"
                 " `export_parameters`."
                 )
         if not Path(json_filepath).exists():
             raise Exception(
                 "Unable to find the JSON file with the input parameters to run"
-                f" QTCAD simulations at ‘{json_filepath}’."
+                f" QTCAD® simulations at ‘{json_filepath}’."
                 " Please make sure to have exported them using"
                 " `export_parameters`."
                 " If a custom path was provided, make sure it points to a valid"
-                " QTCAD JSON file."
+                " QTCAD® JSON file."
                 )
 
         if (self.mesh_file is None) or (not Path(self.mesh_file).exists()):
@@ -934,8 +934,8 @@ class QQTCADRenderer(QRendererAnalysis):
         qtcad_env_found = self._check_conda_env(env_name)
         if not qtcad_env_found:
             raise Exception(
-                f"Unable to find QTCAD's conda environment ‘{env_name}’."
-                " If you have installed QTCAD in a custom environment, please provide its name"
+                f"Unable to find QTCAD®'s conda environment ‘{env_name}’."
+                " If you have installed QTCAD® in a custom environment, please provide its name"
                 " using the parameter `env_name`."
                 )
 
@@ -943,7 +943,7 @@ class QQTCADRenderer(QRendererAnalysis):
         conda_cmd = shutil.which("conda")
 
         self.logger.info("================")
-        self.logger.info("Running QTCAD...")
+        self.logger.info("Running QTCAD®...")
         self.logger.info("================")
         process = subprocess.Popen(
             [
@@ -970,9 +970,9 @@ class QQTCADRenderer(QRendererAnalysis):
         solver: str,
         json_filepath: str | Path,
     ) -> None:
-        """Load specific post-simulation data from QTCAD’s solvers.
+        """Load specific post-simulation data from QTCAD®’s solvers.
 
-        QTCAD’s capacitance and Maxwell eigenmode solvers register additional data
+        QTCAD®’s capacitance and Maxwell eigenmode solvers register additional data
         associated to electromagnetic field (eigenmode only) and refined mesh
         (capacitance and eigenmode) files after simulations are run. These data are
         useful for additional analyses.
@@ -981,14 +981,14 @@ class QQTCADRenderer(QRendererAnalysis):
             solver (str): Which solver to load the associated post-simulation data.
                 Should be `"cap"` (capacitance matrix) or `"eigs"` (Maxwell eigenmodes).
             json_filepath (str): Path to JSON file with post-simulation data written by
-                the wrapper around QTCAD.
+                the wrapper around QTCAD®.
         """
 
         with open(json_filepath) as f:
             json_data = json.load(f)
 
         validated = QtcadInputParams(**json_data)
-        error_msg_template = ("Unable to load post-simulation data from QTCAD’s"
+        error_msg_template = ("Unable to load post-simulation data from QTCAD®’s"
                               " {solver} solver.")
         if solver == "eigs":
             self.eig_refined_mesh_file = validated.eig_refined_mesh_file
@@ -1015,7 +1015,7 @@ class QQTCADRenderer(QRendererAnalysis):
         """Load capacitance matrix from file.
 
         Args:
-            filename (str, optional): Path to the pickle file containing QTCAD's capacitance
+            filename (str, optional): Path to the pickle file containing QTCAD®'s capacitance
             matrix (a dictionary; units: femtofarads). Defaults to `None`, loading the
             default path to the file written by the capacitance extractor.
 
@@ -1029,7 +1029,7 @@ class QQTCADRenderer(QRendererAnalysis):
         input_file = Path(filepath)
         if not input_file.exists():
             raise Exception(
-                f"Unable to load the capacitance matrix generated by QTCAD from ‘{filepath}’."
+                f"Unable to load the capacitance matrix generated by QTCAD® from ‘{filepath}’."
                 " Please make sure the path to the file is correct and the capacitance"
                 " extraction method has ran successfully.",
                 )
@@ -1058,7 +1058,7 @@ class QQTCADRenderer(QRendererAnalysis):
         """Load Maxwell eigenmodes from file.
 
         Args:
-            filename (str, optional): Path to the pickle file containing QTCAD's Maxwell
+            filename (str, optional): Path to the pickle file containing QTCAD®'s Maxwell
             eigenmode calculation result (units: gigahertz). Defaults to `None`, loading the
             default path to the file written by the Maxwell eigenmode extractor.
 
@@ -1072,7 +1072,7 @@ class QQTCADRenderer(QRendererAnalysis):
         input_file = Path(filepath)
         if not input_file.exists():
             raise Exception(
-                f"Unable to load Maxwell eigenmodes generated by QTCAD from ‘{filepath}’."
+                f"Unable to load Maxwell eigenmodes generated by QTCAD® from ‘{filepath}’."
                 " Please make sure the path to the file is correct and the eigenmode"
                 " extraction method has ran successfully."
                 )
@@ -1110,7 +1110,7 @@ class QQTCADRenderer(QRendererAnalysis):
                 Defaults to `True`.
             save (bool, optional): Whether to save the plot of the electric fields as a
                 PNG file. Defaults to `True`.
-            vtu_file (str | Path | None): Path to a VTU file containing QTCAD’s
+            vtu_file (str | Path | None): Path to a VTU file containing QTCAD®’s
                 electromagnetic fields. If `None`, will automatically consider the VTU
                 file generated by the current `QQTCADRenderer` set up. Must be passed
                 only if loading results from a different simulation set up.
@@ -1236,7 +1236,7 @@ class QQTCADRenderer(QRendererAnalysis):
                 Defaults to `True`.
             save (bool, optional): Whether to save the plot of the electric field as a
                 PNG file. Defaults to `True`.
-            vtu_file (str | Path | None): Path to a VTU file containing QTCAD’s
+            vtu_file (str | Path | None): Path to a VTU file containing QTCAD®’s
                 electromagnetic fields. If `None`, will automatically consider the VTU
                 file generated by the current `QQTCADRenderer` set up. Must be passed
                 only if loading results from a different simulation set up.

--- a/qiskit_metal/renderers/renderer_qtcad/qtcad_renderer.py
+++ b/qiskit_metal/renderers/renderer_qtcad/qtcad_renderer.py
@@ -180,6 +180,7 @@ class QQTCADRenderer(QRendererAnalysis):
 
         super().__init__(design=design, initiate=initiate, options=options)
 
+        self.geo_file = self._options["geo_filepath"]
         self.mesh_file = None
         self.json_filepath = None
         self.cap_refined_mesh_file = None
@@ -769,39 +770,60 @@ class QQTCADRenderer(QRendererAnalysis):
         """Launch Gmsh GUI for viewing the model."""
         self.gmsh.launch_gui()
 
+    def export_geometry(
+        self,
+        geometry_file: Optional[str] = None,
+    ) -> str:
+        """Export the design to a geometry file using Gmsh.
+
+        Args:
+            geometry_file (Optional[str], optional): File path to which to save
+              the geometry file. If `None`, uses the value of the `geo_filepath`
+            entry in QQTCADRenderer’s options dictionary. Default: `None`.
+
+        Returns:
+            str: File path to the exported geometry file.
+        """
+
+        if geometry_file is None:
+            if self._options["geo_filepath"] is not None:
+                self.geo_file = self._options["geo_filepath"]
+        else:
+            self.geo_file = geometry_file
+
+        # Guarantee the path to the mesh file exists.
+        Path(self.geo_file).parent.resolve().mkdir(exist_ok=True, parents=True)
+        self.gmsh.export_geometry(self.geo_file)
+
+        return self.geo_file
+
     def export_mesh(
         self,
         mesh_file: Optional[str] = None,
-        geometry_file: Optional[str] = None,
-    ):
-        """Export the mesh and geometry files.
+    ) -> str:
+        """Export the mesh.
 
         The mesh is exported with unit scaling factor.
 
         Args:
             mesh_file (Optional[str], optional): File path to which to save the
-              mesh file.
-            geometry_file (Optional[str], optional): File path to which to save
-              the geometry file.
+              mesh file. If `None`, uses the value of the `mesh_filepath`
+              entry in QQTCADRenderer’s options dictionary. Default: `None`.
+
+        Returns:
+            str: File path to the exported mesh file.
         """
 
-        if geometry_file is None:
-            geometry_file = self._options["geo_filepath"]
-
-        # We check against `None` once again because
-        # `self._options["geo_filepath"]` is `None` if AMR is not enabled.
-        if geometry_file is not None:
-            Path(geometry_file).parent.resolve().mkdir(exist_ok=True, parents=True)
-            self.gmsh.export_geometry(geometry_file)
-
         if mesh_file is None:
-            mesh_file = self._options["mesh_filepath"]
-
-        self.mesh_file = mesh_file
+            self.mesh_file = self._options["mesh_filepath"]
+        else:
+            self.mesh_file = mesh_file
 
         # Guarantee the path to the mesh file exists.
         Path(self.mesh_file).parent.resolve().mkdir(exist_ok=True, parents=True)
         self.gmsh.export_mesh(self.mesh_file, scaling_factor=1)
+
+        return self.mesh_file
 
     def _validate_options(self):
         if not isinstance(self._options["capacitance_raw"], (type(None), dict)):
@@ -928,8 +950,15 @@ class QQTCADRenderer(QRendererAnalysis):
         if (self.mesh_file is None) or (not Path(self.mesh_file).exists()):
             raise Exception(
                 "Unable to find the mesh file."
-                " Please make sure to have generated it using `export_mesh`."
-                )
+                " Please make sure to have generated it using `export_mesh`.")
+
+        geo_file = self._options["geo_filepath"]
+        adaptive = self._options["adaptive"]
+        if (geo_file
+                is not None) and (not Path(geo_file).exists()) and adaptive:
+            raise Exception(
+                "Unable to find the mesh file."
+                " Please make sure to have generated it using `export_design`.")
 
         qtcad_env_found = self._check_conda_env(env_name)
         if not qtcad_env_found:

--- a/qiskit_metal/renderers/renderer_qtcad/qtcad_renderer.py
+++ b/qiskit_metal/renderers/renderer_qtcad/qtcad_renderer.py
@@ -147,11 +147,11 @@ class QQTCADRenderer(QRendererAnalysis):
         maxwell_emode_raw=None,
     )
     default_junction_params = dict(
-        bnd_spec = None,
-        inductance = None,
-        length = None,
-        width = None,
-        dir = None,
+        bnd_spec=None,
+        inductance=None,
+        length=None,
+        width=None,
+        dir=None,
     )
 
     name = "qtcad"
@@ -833,11 +833,12 @@ class QQTCADRenderer(QRendererAnalysis):
 
     def _validate_options(self):
         if not isinstance(self._options["capacitance_raw"], (type(None), dict)):
-            error_msg = TypeError("`QQTCADRenderer.capacitance_raw` should either be a dictionary"
-                                  " with the parameters allowed by"
-                                  " `qtcad.device.maxwell_eigenmode.SolverParams` or left unset."
-                                  " Please check the `options` parameters used to instantiate the"
-                                  " QTCAD® renderer.")
+            error_msg = TypeError(
+                "`QQTCADRenderer.capacitance_raw` should either be a dictionary"
+                " with the parameters allowed by"
+                " `qtcad.device.maxwell_eigenmode.SolverParams` or left unset."
+                " Please check the `options` parameters used to instantiate the"
+                " QTCAD® renderer.")
             self.logger.error(error_msg)
             raise error_msg
         if isinstance(self._options["capacitance_raw"], dict):
@@ -848,12 +849,14 @@ class QQTCADRenderer(QRendererAnalysis):
                 " defaults.")
             self.logger.warning(warning_msg)
 
-        if not isinstance(self._options["maxwell_emode_raw"], (type(None), dict)):
-            error_msg = TypeError("`QQTCADRenderer.maxwell_emode_raw` should either be a"
-                                  " dictionary with the parameters allowed by"
-                                  " `qtcad.device.maxwell_eigenmode.SolverParams` or left unset."
-                                  " Please check the `options` parameters used to instantiate the"
-                                  " QTCAD® renderer.")
+        if not isinstance(self._options["maxwell_emode_raw"],
+                          (type(None), dict)):
+            error_msg = TypeError(
+                "`QQTCADRenderer.maxwell_emode_raw` should either be a"
+                " dictionary with the parameters allowed by"
+                " `qtcad.device.maxwell_eigenmode.SolverParams` or left unset."
+                " Please check the `options` parameters used to instantiate the"
+                " QTCAD® renderer.")
             self.logger.error(error_msg)
             raise error_msg
         if isinstance(self._options["maxwell_emode_raw"], dict):
@@ -913,11 +916,12 @@ class QQTCADRenderer(QRendererAnalysis):
             return True
         return False
 
-    def run_qtcad(self,
-                  solve_for,
-                  json_filepath=None,
-                  env_name="qtcad",
-                  ):
+    def run_qtcad(
+        self,
+        solve_for,
+        json_filepath=None,
+        env_name="qtcad",
+    ):
         """Calls wrapper file in a specific environment
 
             Args:
@@ -941,8 +945,7 @@ class QQTCADRenderer(QRendererAnalysis):
                 "Unable to find the JSON file with the input parameters to run"
                 " QTCAD® simulations."
                 " Please make sure to have exported them using"
-                " `export_parameters`."
-                )
+                " `export_parameters`.")
         if not Path(json_filepath).exists():
             raise Exception(
                 "Unable to find the JSON file with the input parameters to run"
@@ -950,8 +953,7 @@ class QQTCADRenderer(QRendererAnalysis):
                 " Please make sure to have exported them using"
                 " `export_parameters`."
                 " If a custom path was provided, make sure it points to a valid"
-                " QTCAD® JSON file."
-                )
+                " QTCAD® JSON file.")
 
         if (self.mesh_file is None) or (not Path(self.mesh_file).exists()):
             raise Exception(
@@ -972,8 +974,7 @@ class QQTCADRenderer(QRendererAnalysis):
             raise Exception(
                 f"Unable to find QTCAD®'s conda environment ‘{env_name}’."
                 " If you have installed QTCAD® in a custom environment, please provide its name"
-                " using the parameter `env_name`."
-                )
+                " using the parameter `env_name`.")
 
         # Launch a subprocess with unbuffered Python (-u).
         conda_cmd = shutil.which("conda")
@@ -983,8 +984,8 @@ class QQTCADRenderer(QRendererAnalysis):
         self.logger.info("=================")
         process = subprocess.Popen(
             [
-                conda_cmd, "run", "--no-capture-output", "-n", env_name, "python", "-u",
-                qtcad_wrapper_path, solve_for, json_filepath
+                conda_cmd, "run", "--no-capture-output", "-n", env_name,
+                "python", "-u", qtcad_wrapper_path, solve_for, json_filepath
             ],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
@@ -1024,8 +1025,9 @@ class QQTCADRenderer(QRendererAnalysis):
             json_data = json.load(f)
 
         validated = QtcadInputParams(**json_data)
-        error_msg_template = ("Unable to load post-simulation data from QTCAD®’s"
-                              " {solver} solver.")
+        error_msg_template = (
+            "Unable to load post-simulation data from QTCAD®’s"
+            " {solver} solver.")
         if solver == "eigs":
             self.eig_refined_mesh_file = validated.eig_refined_mesh_file
             self.eig_field_file = validated.eig_field_file
@@ -1047,7 +1049,9 @@ class QQTCADRenderer(QRendererAnalysis):
             self.cap_refined_mesh_file = Path(
                 validated.cap_refined_mesh_file).resolve()
 
-    def load_qtcad_capacitance_matrix(self, filepath: Union[str, None] = None) -> pd.DataFrame:
+    def load_qtcad_capacitance_matrix(self,
+                                      filepath: Union[str, None] = None
+                                     ) -> pd.DataFrame:
         """Load capacitance matrix from file.
 
         Args:
@@ -1067,8 +1071,7 @@ class QQTCADRenderer(QRendererAnalysis):
             raise Exception(
                 f"Unable to load the capacitance matrix generated by QTCAD® from ‘{filepath}’."
                 " Please make sure the path to the file is correct and the capacitance"
-                " extraction method has ran successfully.",
-                )
+                " extraction method has ran successfully.",)
 
         with open(filepath, 'rb') as handle:
             cap = pickle.load(handle)
@@ -1079,9 +1082,13 @@ class QQTCADRenderer(QRendererAnalysis):
         sig_conductor_names = np.array(
             list(dict.fromkeys([k[0] for k in cap.keys()]).keys()))
         sig_conductor_length = len(sig_conductor_names)
-        cap_list = [cap[(i, j)] for i in sig_conductor_names for j in sig_conductor_names]
-        cap_matrix_array = np.reshape(cap_list,
-                                        (sig_conductor_length, sig_conductor_length))
+        cap_list = [
+            cap[(i, j)]
+            for i in sig_conductor_names
+            for j in sig_conductor_names
+        ]
+        cap_matrix_array = np.reshape(
+            cap_list, (sig_conductor_length, sig_conductor_length))
         cap_matrix_df = pd.DataFrame(
             cap_matrix_array,
             index=sig_conductor_names,
@@ -1090,7 +1097,9 @@ class QQTCADRenderer(QRendererAnalysis):
 
         return cap_matrix_df
 
-    def load_qtcad_maxwell_eigenmodes(self, filepath: Union[str, None] = None) -> np.ndarray:
+    def load_qtcad_maxwell_eigenmodes(self,
+                                      filepath: Union[str, None] = None
+                                     ) -> np.ndarray:
         """Load Maxwell eigenmodes from file.
 
         Args:
@@ -1110,8 +1119,7 @@ class QQTCADRenderer(QRendererAnalysis):
             raise Exception(
                 f"Unable to load Maxwell eigenmodes generated by QTCAD® from ‘{filepath}’."
                 " Please make sure the path to the file is correct and the eigenmode"
-                " extraction method has ran successfully."
-                )
+                " extraction method has ran successfully.")
 
         with open(filepath, 'rb') as handle:
             eig = pickle.load(handle)

--- a/qiskit_metal/renderers/renderer_qtcad/qtcad_renderer.py
+++ b/qiskit_metal/renderers/renderer_qtcad/qtcad_renderer.py
@@ -801,7 +801,7 @@ class QQTCADRenderer(QRendererAnalysis):
         self,
         mesh_file: Optional[str] = None,
     ) -> tuple[str, str | None]:
-        """Export the mesh and, if AMR is enable, the geometry file..
+        """Export the mesh and, if AMR is enabled, the geometry file.
 
         The mesh is exported with unit scaling factor.
 
@@ -963,8 +963,9 @@ class QQTCADRenderer(QRendererAnalysis):
         if (geo_file
                 is not None) and (not Path(geo_file).exists()) and adaptive:
             raise Exception(
-                "Unable to find the mesh file."
-                " Please make sure to have generated it using `export_design`.")
+                "Unable to find the geometry file."
+                " Please make sure to have generated it using `export_geometry` or"
+                " `export_mesh`.")
 
         qtcad_env_found = self._check_conda_env(env_name)
         if not qtcad_env_found:
@@ -977,9 +978,9 @@ class QQTCADRenderer(QRendererAnalysis):
         # Launch a subprocess with unbuffered Python (-u).
         conda_cmd = shutil.which("conda")
 
-        self.logger.info("================")
+        self.logger.info("=================")
         self.logger.info("Running QTCAD®...")
-        self.logger.info("================")
+        self.logger.info("=================")
         process = subprocess.Popen(
             [
                 conda_cmd, "run", "--no-capture-output", "-n", env_name, "python", "-u",

--- a/qiskit_metal/renderers/renderer_qtcad/qtcad_renderer.py
+++ b/qiskit_metal/renderers/renderer_qtcad/qtcad_renderer.py
@@ -18,8 +18,10 @@ import numpy as np
 import pandas as pd
 import json
 import pickle
+import shapely
 
 from qiskit_metal import Dict, draw
+from qiskit_metal.toolbox_metal.parsing import parse_entry
 from qiskit_metal.renderers.renderer_base import QRendererAnalysis
 from qiskit_metal.renderers.renderer_gmsh.gmsh_renderer import QGmshRenderer
 from qiskit_metal.designs import MultiPlanar
@@ -132,6 +134,13 @@ class QQTCADRenderer(QRendererAnalysis):
         ),
         maxwell_emode_raw=None,
     )
+    default_junction_params = dict(
+        bnd_spec = None,
+        inductance = None,
+        length = None,
+        width = None,
+        dir = None,
+    )
 
     name = "qtcad"
     """name"""
@@ -148,7 +157,7 @@ class QQTCADRenderer(QRendererAnalysis):
             design ('MultiPlanar'): The design.
             layer_types (Union[dict, None]): The type of layer in the format:
               dict(metal=[...], dielectric=[...]). Defaults to `None`.
-            initiate (bool): True to initiate the renderer. Defaults to `False`.
+            initiate (bool): True to initiate the renderer. Defaults to `True`.
             options (Dict, optional): Used to override default options. Defaults
               to `None`.
         """
@@ -173,6 +182,20 @@ class QQTCADRenderer(QRendererAnalysis):
                     "geo_filepath",
             ]:
                 self._options[arg] = None
+
+        # Initialize the dictionary with QTCAD-specific properties associated
+        # to the tunnelling junctions of each qubit.
+        self.junction_params = dict()
+        for junction in self.design.qgeometry.tables["junction"].iloc:
+            qubit_name = self.design._components[junction.component].name
+            if qubit_name in self.junction_params:
+                error_msg = ValueError(
+                    "Currently, QQTCADRenderer does not support multiple"
+                    " tunnelling junctions per qubit.")
+                self.logger.error(error_msg)
+                raise error_msg
+            self.junction_params[
+                qubit_name] = self.default_junction_params.copy()
 
     @property
     def initialized(self):
@@ -455,6 +478,124 @@ class QQTCADRenderer(QRendererAnalysis):
 
         return netlists
 
+    def _current_direction(
+            self,
+            line: shapely.geometry.linestring.LineString) -> Union[str, None]:
+        """Find the direction to be assumed for an element’s current flow.
+
+        We assume a rectangular tunnelling junction and determine its current
+        flow’s direction based on its geometry.
+
+        Args:
+            line (shapely.geometry.linestring.LineString): The `LineString`
+              that defines a junction component.
+
+        Returns:
+            Union[str, None]: the current flow’s direction: `"x"`, `"y"`, with
+              `None` being returned if the element is not defined along either
+              the x or y directions.
+        """
+        # The two elements of `line.coords.xy` give us the coordinates
+        # (x0, x1) and (y0, y1). When flattened and operated by `np.diff`, we
+        # obtain the vector [x1-x0, y1-y0], which we can compare with unit
+        # vectors to determine its direction.
+        direction_vector = np.diff(line.coords.xy).flatten()
+
+        # Unit vectors.
+        unit_x = np.array([1, 0])
+        unit_y = np.array([0, 1])
+
+        # Compare inner products to distinguish the directions.
+        if np.isclose(direction_vector @ unit_y, 0):
+            direction = "x"
+        elif np.isclose(direction_vector @ unit_x, 0):
+            direction = "y"
+        else:
+            direction = None
+
+        return direction
+
+    def set_up_junction(self, qubit: str, inductance: float,
+                        length: Union[float, int, str]) -> pd.DataFrame:
+        """Define a qubit’s tunnelling junction (inductive port) properties.
+
+        For eigenmode simulations, the tunnelling junction is described as an
+        inductive port with linear inductance. Whilst the width is computed
+        automatically from the qubit geometry, the length needs to be passed
+        manually.
+
+        Note that, for `QQTCADRenderer`, a design’s
+        `qgeometry.tables['junction']` does not fully describe the properties
+        of the QPU’s tunnelling junctions. One also needs to inspect
+        `QQTCADRenderer.junction_params`, which this method updates.
+
+        Args:
+            qubit (str): The name of the qubit whose junction’s properties
+              we will set up.
+            inductance (float): The inductance (in henries) of the Josephson
+              tunnelling junction approximated as a linear inductor.
+            length (Union[float, int, str]): Length of the inductive port
+              describing the junction. It should be the distance between
+              charge islands or the gap between the island and the ground
+              plane.
+
+        Returns:
+            pd.DataFrame: Table with the properties of the junction.
+        """
+
+        if qubit not in self.junction_params:
+            error_msg = KeyError(f"Qubit labelled ‘{qubit}’ not found.")
+            self.logger.error(error_msg)
+            raise error_msg
+
+        # The name of the physical groups associated to tunnelling junctions
+        # in `QGmshRenderer` always follow the same pattern.
+        junction_surface = f"{qubit}_rect_jj"
+
+        # Access the table with the properties of the first tunnelling
+        # junction of the qubit.
+        junction_table = self.design.components[qubit].qgeometry_table(
+            "junction")
+        junction_qgeom = junction_table.iloc[0]
+
+        # Whilst the width is easily accessible from the qubit’s geometry¹,
+        # there is not a single attribute that stores information on the
+        # length of junctions across all transmon-like components. For
+        # instance, for `qiskit_metal.qlibrary.TransmonPocket` it would be
+        # `pad_gap`, whilst for `qiskit_metal.qlibrary.TransmonCross` is
+        # `cross_gap`.
+        # ¹ Concerning the width, some components may have the specific
+        #   property `inductor_width`, whilst other do not.
+        junction_width = parse_entry(junction_qgeom.width)
+        junction_length = parse_entry(length) / self.options["mesh_scale"]
+
+        # Try to determine the direction for the inductive port’s current
+        # flow.
+        junction_direction = self._current_direction(junction_qgeom.geometry)
+        if junction_direction is None:
+            error_msg = ValueError(
+                "Currently, QQTCADRenderer does not support Josephson"
+                " junctions (inductive ports) not aligned along the x- or"
+                " y-axes.")
+            self.logger.error(error_msg)
+            raise error_msg
+
+        self.junction_params[qubit].update(
+            bnd_spec=junction_surface,
+            inductance=inductance,
+            length=junction_length,
+            width=junction_width,
+            dir=junction_direction,
+        )
+
+        # Create a `pandas.DataFrame` to make easier to inspect the parsed
+        # properties of the junction.
+        junction_params_df = pd.DataFrame.from_dict({
+            key: [value] for key, value in self.junction_params[qubit].items()
+        })
+
+        return junction_params_df
+
     def get_gnd_qgeoms(self, open_pins: Union[list, None] = None) -> list[str]:
         """Obtain a list of qgeometry names associated with pins shorted to
         ground.
@@ -694,6 +835,7 @@ class QQTCADRenderer(QRendererAnalysis):
         data = {
             "gmsh_physical_groups": self.gmsh.physical_groups,
             "_conductors": self.conductors,
+            "_inductive_ports": self.junction_params,
             "sample_holder": self.sample_holder,
             "qtcad_options": {
                 k: v for k, v in self._options.items() if k != "materials"
@@ -800,7 +942,6 @@ class QQTCADRenderer(QRendererAnalysis):
             print(line, end="")
 
         process.wait()
-
 
     def load_qtcad_capacitance_matrix(self, filepath: Union[str, None] = None) -> pd.DataFrame:
         """Load capacitance matrix from file.

--- a/qiskit_metal/renderers/renderer_qtcad/qtcad_renderer.py
+++ b/qiskit_metal/renderers/renderer_qtcad/qtcad_renderer.py
@@ -39,10 +39,17 @@ EIGENMODE_LAYER_TEMPLATE = "abs(electric field) [V/m] - mode {n}"
 
 def sanitize_string(string: str) -> str:
     """Remove a string’s non-alphanumeric characters/spaces/underscores/hyphens.
+
+    Args:
+        string (str): The input string to be parsed.
+
+    Returns:
+        str: The parsed string.
     """
     filename = re.sub(r'[^\w\s\-_.]', '', string)
     filename = filename.replace(' ', '_')
     return filename
+
 
 class QQTCADRenderer(QRendererAnalysis):
     """Extends QRendererAnalysis class to use QTCAD’s API with Gmsh’s meshes.

--- a/qiskit_metal/renderers/renderer_qtcad/qtcad_renderer.py
+++ b/qiskit_metal/renderers/renderer_qtcad/qtcad_renderer.py
@@ -800,8 +800,8 @@ class QQTCADRenderer(QRendererAnalysis):
     def export_mesh(
         self,
         mesh_file: Optional[str] = None,
-    ) -> str:
-        """Export the mesh.
+    ) -> tuple[str, str | None]:
+        """Export the mesh and, if AMR is enable, the geometry file..
 
         The mesh is exported with unit scaling factor.
 
@@ -811,8 +811,14 @@ class QQTCADRenderer(QRendererAnalysis):
               entry in QQTCADRenderer’s options dictionary. Default: `None`.
 
         Returns:
-            str: File path to the exported mesh file.
+            tuple[str, str | None]: If AMR is enabled, 2-tuple with the file
+              path to the exported mesh and geometry files. Otherwise, the
+              second element, associated to the geometry file is `None`.
         """
+
+        geo_file = None
+        if self._options["adaptive"]:
+            geo_file = self.export_geometry()
 
         if mesh_file is None:
             self.mesh_file = self._options["mesh_filepath"]
@@ -823,7 +829,7 @@ class QQTCADRenderer(QRendererAnalysis):
         Path(self.mesh_file).parent.resolve().mkdir(exist_ok=True, parents=True)
         self.gmsh.export_mesh(self.mesh_file, scaling_factor=1)
 
-        return self.mesh_file
+        return self.mesh_file, geo_file
 
     def _validate_options(self):
         if not isinstance(self._options["capacitance_raw"], (type(None), dict)):

--- a/qiskit_metal/renderers/renderer_qtcad/qtcad_renderer.py
+++ b/qiskit_metal/renderers/renderer_qtcad/qtcad_renderer.py
@@ -886,10 +886,6 @@ class QQTCADRenderer(QRendererAnalysis):
 
         return frequencies / 1e9
 
-        """Plot slices of all the eigenmodes stored in a VTU file on a grid.
-
-        Args
-            TODO
     def plot_eigenmodes(
         self,
         vtu_file: str,
@@ -899,6 +895,30 @@ class QQTCADRenderer(QRendererAnalysis):
         show: bool = True,
         save: bool = False,
     ) -> Union[str, None]:
+        """Plot a grid with z=0 slices of all the eigenmodes stored in a VTU file.
+
+        PyVista is used to generate the plots of the absolute value of the electric
+        field associated to different Maxwell eigenmodes.
+
+        Args:
+            vtu_file (str): Path to the VTU file containing QTCAD’s electromagnetic
+                fields.
+            num_modes (Union[int, None], optional): The number of modes to plot,
+                starting from the first one. Defaults to `None`, which plots all modes.
+                However, if loading a VTU file from a different simulation, it must be
+                set accordingly.
+            cmap (str, optional): Name of the colour map to be used. Must be a colour
+                map supported by PyVista. Defaults to `"magma"`.
+            log (bool, optional): Whether to use a logarithmic scale when mapping data
+                to colours. Defaults to `True`.
+            show (bool, optional): Whether to display the plot of the electric fields.
+                Defaults to `True`.
+            save (bool, optional): Whether to save the plot of the electric fields as a
+                PNG file. Defaults to `True`.
+
+        Returns:
+            Union[str, None]: `str` with the path to the exported image file if `save`
+                was enabled. Otherwise, `None`.
         """
 
         if num_modes is None:
@@ -980,11 +1000,8 @@ class QQTCADRenderer(QRendererAnalysis):
 
         del mesh
 
-        """Plot a slice at z=0 of a given eigenmode stored in a VTU file.
         return str(output_file.resolve())
 
-        Args
-            TODO
     def plot_eigenmode(
         self,
         vtu_file: str,
@@ -994,6 +1011,28 @@ class QQTCADRenderer(QRendererAnalysis):
         show: bool = True,
         save: bool = False,
     ) -> Union[str, None]:
+        """Plot the z=0 slice of a given eigenmode stored in a VTU file.
+
+        PyVista is used to generate the plot of the absolute value of the electric
+        field associated to the desired Maxwell eigenmode.
+
+        Args:
+            vtu_file (str): Path to the VTU file containing QTCAD’s electromagnetic
+                fields.
+            n (int): Index of the desired eigenmode. Indexing starts from 1, the ground
+                state.
+            cmap (str, optional): Name of the colour map to be used. Must be a colour
+                map supported by PyVista. Defaults to `"magma"`.
+            log (bool, optional): Whether to use a logarithmic scale when mapping data
+                to colours. Defaults to `True`.
+            show (bool, optional): Whether to display the plot of the electric field.
+                Defaults to `True`.
+            save (bool, optional): Whether to save the plot of the electric field as a
+                PNG file. Defaults to `True`.
+
+        Returns:
+            Union[str, None]: `str` with the path to the exported image file if `save`
+                was enabled. Otherwise, `None`.
         """
 
         input_file_path = Path(vtu_file)

--- a/qiskit_metal/renderers/renderer_qtcad/wrapper.py
+++ b/qiskit_metal/renderers/renderer_qtcad/wrapper.py
@@ -87,7 +87,7 @@ class QQTCADWrapper():
             json.dump(self.json_data, f, indent=2)
 
     def setup(self, bnd_conditions) -> None:
-        """Set up QTCAD.
+        """Set up QTCAD®.
 
         Args:
             bnd_conditions : Boundary conditions assigned on conductors.
@@ -192,7 +192,7 @@ class QQTCADWrapper():
         if len(self.signal_conductors.keys()) == 0:
             logger.warning(
                 "WARNING: No conductors were assigned to a signal conductor."
-                " QTCAD will not be able to extract the capacitance matrix for"
+                " QTCAD® will not be able to extract the capacitance matrix for"
                 " this design.")
 
         # Qiskit Metal assumes the presence of the ground(_plane) conductor in
@@ -228,7 +228,7 @@ class QQTCADWrapper():
         # self.device.new_infinity_bnd("vacuum_box_sfs")
 
     def solve_eigs(self):
-        """Solve for Maxwell eigenmodes using QTCAD.
+        """Solve for Maxwell eigenmodes using QTCAD®.
 
         Returns:
             The frequencies are stored in `device.maxwell_freqs`. The fields are
@@ -361,7 +361,7 @@ class QQTCADWrapper():
                          " Try calling `solve_eigs` before.")
 
     def solve_cap(self):
-        """Compute the capacitance matrix using QTCAD.
+        """Compute the capacitance matrix using QTCAD®.
 
         It is stored in the attribute `capacitance_matrix`, being a
         dict[tuple[str,str], float].
@@ -388,7 +388,7 @@ class QQTCADWrapper():
 
         self.solver_params_cap = solver_params_cap
 
-        logger.info("Running QTCAD capacitance extraction.")
+        logger.info("Running QTCAD® capacitance extraction.")
         self.capacitance_matrix = self.compute_capacitance_matrix()
 
     def save_capacitance_matrix(self, path: str) -> None:

--- a/qiskit_metal/renderers/renderer_qtcad/wrapper.py
+++ b/qiskit_metal/renderers/renderer_qtcad/wrapper.py
@@ -29,6 +29,7 @@ class QTCADInputParams:
 
     gmsh_physical_groups: dict
     _conductors: dict
+    _inductive_ports: dict
     sample_holder: bool
     qtcad_options: dict
 
@@ -49,6 +50,7 @@ class QQTCADWrapper():
         self.json_data = json_data
         self.gmsh_physical_groups = None
         self._conductors = None
+        self._inductive_ports = None
         self.sample_holder = None
         self.qtcad_options = None
 
@@ -60,6 +62,7 @@ class QQTCADWrapper():
         validated = QTCADInputParams(**data)
         self.gmsh_physical_groups = validated.gmsh_physical_groups
         self._conductors = validated._conductors
+        self._inductive_ports = validated._inductive_ports
         self.sample_holder = validated.sample_holder
         self._options = validated.qtcad_options
 
@@ -147,6 +150,7 @@ class QQTCADWrapper():
         self.signal_conductors = dict()
         ground_conductor = []
         self.conductors = []
+        self.inductive_ports = []
 
         for layer, ph_geoms in self.gmsh_physical_groups.items():
             # ph_geoms: set of (label, Gmsh physical group ID)
@@ -190,6 +194,15 @@ class QQTCADWrapper():
         elif bnd_conditions == "PEC":
             for boundary in self.conductors:
                 self.device.new_pec_bnd(boundary)
+
+        # Set boundary conditions for the inductive ports (tunnelling
+        # junctions). The port parameters are fully specified by the
+        # dictionaries created by `QQTCADRenderer.set_up_junction`.
+        for qubit_name, junction_params in self._inductive_ports.items():
+            # Ignore junctions that were not set up.
+            if junction_params["bnd_spec"] is None:
+                continue
+            self.device.new_inductor(**junction_params)
 
         # FIXME Whilst we do not have a way of setting infinity boundary
         # conditions, let us not touch on `vacuum_box_sfs`, which then implies

--- a/qiskit_metal/renderers/renderer_qtcad/wrapper.py
+++ b/qiskit_metal/renderers/renderer_qtcad/wrapper.py
@@ -68,8 +68,9 @@ class QQTCADWrapper():
 
         # Check if the keys to be updated are a valid subset of the possible fields.
         if not solver_data.keys() <= self.json_data.keys():
-            error_msg = ValueError("Invalid (superfluous) data found when trying to"
-                                   " update JSON data.")
+            error_msg = ValueError(
+                "Invalid (superfluous) data found when trying to update JSON data."
+            )
             logger.error(error_msg)
             raise error_msg
 
@@ -187,7 +188,8 @@ class QQTCADWrapper():
             if conductor == "gnd":
                 ground_conductor += signal_conductor_surfaces
             else:
-                self.signal_conductors[geom_names[-1]] = signal_conductor_surfaces
+                self.signal_conductors[
+                    geom_names[-1]] = signal_conductor_surfaces
 
         if len(self.signal_conductors.keys()) == 0:
             logger.warning(
@@ -263,8 +265,9 @@ class QQTCADWrapper():
         # Parse parameters.
         self.solver_params_eig = solver_params_eig
         qtcad_solver_eigs = QtcadSolverEig(
-            self.device, self.solver_params_eig, geo_file=self._options["geo_filepath"]
-        )
+            self.device,
+            self.solver_params_eig,
+            geo_file=self._options["geo_filepath"])
         self.solver_eig = qtcad_solver_eigs
 
         # Solve.
@@ -376,7 +379,8 @@ class QQTCADWrapper():
             # Reduced set of parameters.
             solver_params_cap.tol_rel = options_cap["tol_rel"]
             solver_params_cap.tol_abs = options_cap["tol_abs"]
-            solver_params_cap.min_converged_iters = options_cap["min_converged_iters"]
+            solver_params_cap.min_converged_iters = options_cap[
+                "min_converged_iters"]
         else:
             # Pass parameters directly to `qtcad.device.capacitance.SolverParams`.
             solver_params_cap = QtcadSolverCapParams(options_cap_raw)
@@ -405,9 +409,13 @@ class QQTCADWrapper():
         sig_conductor_length = len(sig_conductor_names)
 
         # Create ordered capacitance matrix.
-        cap_list = [cap[(i, j)] for i in sig_conductor_names for j in sig_conductor_names]
-        cap_matrix_array = np.reshape(cap_list,
-                                      (sig_conductor_length, sig_conductor_length))
+        cap_list = [
+            cap[(i, j)]
+            for i in sig_conductor_names
+            for j in sig_conductor_names
+        ]
+        cap_matrix_array = np.reshape(
+            cap_list, (sig_conductor_length, sig_conductor_length))
         return cap_matrix_array
 
     def compute_capacitance_matrix(self) -> dict[tuple[str, str], float]:
@@ -417,10 +425,10 @@ class QQTCADWrapper():
              dict: Capacitance matrix in femtofarads between the conductors.
         """
 
-        qtcad_solver = QtcadSolverCap(
-            self.device, self.signal_conductors, self.solver_params_cap, geo_file = self._options[
-                "geo_filepath"]
-        )
+        qtcad_solver = QtcadSolverCap(self.device,
+                                      self.signal_conductors,
+                                      self.solver_params_cap,
+                                      geo_file=self._options["geo_filepath"])
 
         # dict[tuple[str,str], float]
         cap_out = qtcad_solver.solve()
@@ -480,7 +488,8 @@ def main_solve_eigs(json_file):
 
 if __name__ == "__main__":
     if len(sys.argv) < 3:
-        print("Usage: python wrapper.py quantity-to-solve-for path-to-json-file")
+        print(
+            "Usage: python wrapper.py quantity-to-solve-for path-to-json-file")
         sys.exit(1)
 
     solve_for = sys.argv[1]

--- a/qiskit_metal/renderers/renderer_qtcad/wrapper.py
+++ b/qiskit_metal/renderers/renderer_qtcad/wrapper.py
@@ -5,10 +5,12 @@ import numpy as np
 import sys
 import logging
 import pickle
+from copy import deepcopy
 
 logging.basicConfig()
 logger = logging.getLogger("qtcad")
 
+from qtcad_base import QtcadInputParams, QtcadConstants
 from qtcad.device import Device as qtcad_device
 from qtcad.device.mesh3d import Mesh as qtcad_mesh
 from qtcad.device import materials as qtcad_materials
@@ -17,37 +19,24 @@ from qtcad.device.capacitance import SolverParams as QtcadSolverCapParams
 from qtcad.device.maxwell_eigenmode import Solver as QtcadSolverEig
 from qtcad.device.maxwell_eigenmode import SolverParams as QtcadSolverEigParams
 
-from dataclasses import dataclass
-
-QISKIT_CAPACITANCE_SCALE = 1e-15
-
-QTCAD_CAP_OUTPUT_FILENAME = "qtcad_output_cap.pickle"
-QTCAD_EIG_OUTPUT_FILENAME = "qtcad_output_eigs.pickle"
-
-@dataclass
-class QTCADInputParams:
-
-    gmsh_physical_groups: dict
-    _conductors: dict
-    _inductive_ports: dict
-    sample_holder: bool
-    qtcad_options: dict
-
 
 class QQTCADWrapper():
 
     name = "qtcad"
 
-    def __init__(self, json_data=None):
+    def __init__(self, json_file: None | str | Path = None) -> None:
         """
         Args:
-            json_data : Parameters imported from QQTCADRenderer.
+            json_file (None|str|Path) : File path to the JSON file with the parameters
+            from `QQTCADRenderer`. If `None`, will use its default value
+            `"qtcad_data.json"`.
         """
 
-        if json_data is None:
-            json_data = "qtcad_data.json"
+        if json_file is None:
+            json_file = QtcadConstants.DEFAULT_JSON_FILENAME
 
-        self.json_data = json_data
+        self.json_file = json_file
+        self.json_data = None
         self.gmsh_physical_groups = None
         self._conductors = None
         self._inductive_ports = None
@@ -56,10 +45,11 @@ class QQTCADWrapper():
 
     def load_and_validate(self):
 
-        with open(self.json_data) as f:
-            data = json.load(f)
+        with open(self.json_file) as f:
+            self.json_data = json.load(f)
 
-        validated = QTCADInputParams(**data)
+        # Work with a copy, as we need the original serializable data.
+        validated = QtcadInputParams(**deepcopy(self.json_data))
         self.gmsh_physical_groups = validated.gmsh_physical_groups
         self._conductors = validated._conductors
         self._inductive_ports = validated._inductive_ports
@@ -67,6 +57,34 @@ class QQTCADWrapper():
         self._options = validated.qtcad_options
 
         self._options["materials"] = dict(substrate=qtcad_materials.Si,)
+
+    def update_json(self, solver_data: dict) -> None:
+        """Update already-existing entries of the original input JSON data file.
+
+        Args:
+            solver_data (dict): Dictionary with the entries to be updated. It must be
+                serializable.
+        """
+
+        # Check if the keys to be updated are a valid subset of the possible fields.
+        if not solver_data.keys() <= self.json_data.keys():
+            error_msg = ValueError("Invalid (superfluous) data found when trying to"
+                                   " update JSON data.")
+            logger.error(error_msg)
+            raise error_msg
+
+        # Check if the data-to-be-updated is serializable.
+        try:
+            _ = json.dumps(solver_data)
+        except (TypeError, OverflowError):
+            error_msg = ValueError("Invalid (non-serializable) input data.")
+            logger.error(error_msg)
+            raise error_msg
+
+        self.json_data.update(solver_data)
+
+        with open(self.json_file, "w") as f:
+            json.dump(self.json_data, f, indent=2)
 
     def setup(self, bnd_conditions) -> None:
         """Set up QTCAD.
@@ -218,6 +236,9 @@ class QQTCADWrapper():
             corresponding field finding methods such as `device.e_field`.
         """
 
+        refined_mesh_file = None
+        field_file = None
+
         # Instantiate SolverParams and load common attributes from the `_options`
         # attribute.
         options_maxwell_emode = self._options["maxwell_emode"]
@@ -228,7 +249,8 @@ class QQTCADWrapper():
             # Reduced set of parameters.
             solver_params_eig.num_modes = options_maxwell_emode["num_modes"]
             solver_params_eig.tol_rel = options_maxwell_emode["tol_rel"]
-            solver_params_eig.min_converged_iters = options_maxwell_emode["min_converged_iters"]
+            solver_params_eig.min_converged_iters = options_maxwell_emode[
+                "min_converged_iters"]
         else:
             # Pass parameters directly to `qtcad.device.maxwell_eigenmode.SolverParams`.
             solver_params_eig = QtcadSolverEigParams(options_maxwell_emode_raw)
@@ -247,6 +269,15 @@ class QQTCADWrapper():
 
         # Solve.
         qtcad_solver_eigs.solve()
+
+        # Update JSON data from post-simulation solver attributes.
+        if len(qtcad_solver_eigs.refined_mesh_files) > 0:
+            refined_mesh_file = qtcad_solver_eigs.refined_mesh_files[-1]
+        if ".vtu" in str(qtcad_solver_eigs.field_files[-1][0]):
+            field_file = qtcad_solver_eigs.field_files[-1][0]
+        solver_data = dict(eig_refined_mesh_file=str(refined_mesh_file),
+                           eig_field_file=str(field_file))
+        self.update_json(solver_data)
 
     def get_energy_e(self):
         """Finds the total electric energy in the device from the electric field.
@@ -387,15 +418,22 @@ class QQTCADWrapper():
         """
 
         qtcad_solver = QtcadSolverCap(
-            self.device, self.signal_conductors, self.solver_params_cap, geo_file=self._options["geo_filepath"]
+            self.device, self.signal_conductors, self.solver_params_cap, geo_file = self._options[
+                "geo_filepath"]
         )
 
         # dict[tuple[str,str], float]
         cap_out = qtcad_solver.solve()
 
+        # Update JSON data from post-simulation solver attributes.
+        if len(qtcad_solver.refined_mesh_files) > 0:
+            refined_mesh_file = qtcad_solver.refined_mesh_files[-1]
+        solver_data = dict(cap_refined_mesh_file=str(refined_mesh_file))
+        self.update_json(solver_data)
+
         for cap in cap_out.keys():
             # Scale capacitance to femtofarads.
-            cap_out[cap] /= QISKIT_CAPACITANCE_SCALE
+            cap_out[cap] /= QtcadConstants.QISKIT_CAPACITANCE_SCALE
             # Convert np.float64 to float to avoid issues with pickle files.
             # See https://github.com/numpy/numpy/issues/24844
             # FIXME: When Qiskit Metal updates to Numpy >2, this can be removed.
@@ -404,15 +442,16 @@ class QQTCADWrapper():
         return cap_out
 
 
-def main_solve_cap(json_data):
+def main_solve_cap(json_file):
 
-    qtcad_wrapper = QQTCADWrapper(json_data=json_data)
+    qtcad_wrapper = QQTCADWrapper(json_file=json_file)
     qtcad_wrapper.load_and_validate()
     qtcad_wrapper.setup("Dirichlet")
 
     qtcad_wrapper.solve_cap()
-    # Save results as a pickle file to be ingested by the QQTCADRenderer.
-    filepath = Path(qtcad_wrapper._options["output_dir"]) / QTCAD_CAP_OUTPUT_FILENAME
+    # Save results as a pickle file to be ingested by `QQTCADRenderer`.
+    filepath = Path(qtcad_wrapper._options["output_dir"]
+                   ) / QtcadConstants.QTCAD_CAP_OUTPUT_FILENAME
     filepath.parent.resolve().mkdir(exist_ok=True, parents=True)
     with open(filepath, 'wb') as file_handle:
         pickle.dump(qtcad_wrapper.capacitance_matrix,
@@ -420,16 +459,18 @@ def main_solve_cap(json_data):
                     protocol=pickle.HIGHEST_PROTOCOL)
 
 
-def main_solve_eigs(json_data):
+def main_solve_eigs(json_file):
 
-    qtcad_wrapper = QQTCADWrapper(json_data=json_data)
+    qtcad_wrapper = QQTCADWrapper(json_file=json_file)
     qtcad_wrapper.load_and_validate()
     qtcad_wrapper.setup("PEC")
 
     qtcad_wrapper.solve_eigs()
 
-    Path(qtcad_wrapper._options["output_dir"]).resolve().mkdir(exist_ok=True, parents=True)
-    filepath = Path(qtcad_wrapper._options["output_dir"]) / QTCAD_EIG_OUTPUT_FILENAME
+    Path(qtcad_wrapper._options["output_dir"]).resolve().mkdir(exist_ok=True,
+                                                               parents=True)
+    filepath = Path(qtcad_wrapper._options["output_dir"]
+                   ) / QtcadConstants.QTCAD_EIG_OUTPUT_FILENAME
 
     with open(filepath, 'wb') as file_handle:
         pickle.dump(qtcad_wrapper.device.maxwell_freqs.tolist(),
@@ -443,12 +484,12 @@ if __name__ == "__main__":
         sys.exit(1)
 
     solve_for = sys.argv[1]
-    json_data = sys.argv[2]
+    json_file = sys.argv[2]
 
     if solve_for == "cap":
-        main_solve_cap(json_data)
+        main_solve_cap(json_file)
     elif solve_for == "eigs":
-        main_solve_eigs(json_data)
+        main_solve_eigs(json_file)
     else:
         print(f"Wrong quantity to solve for: {solve_for}."
               " Use `cap` for capacitance or `eigs` for Maxwell eigenvalues.")


### PR DESCRIPTION
- Add support to inductive ports (tunnelling junctions) for eigenmode simulations.
- Add methods to plot slices of eigenmodes via PyVista.

These changes are up-to-date with the API of QTCAD® 2.1.1.